### PR TITLE
263 - Change measure when entering value

### DIFF
--- a/backend/src/main/kotlin/com/infowings/catalog/common/DecimalNumber.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/common/DecimalNumber.kt
@@ -14,6 +14,9 @@ actual class DecimalNumber(val value: BigDecimal) {
     actual operator fun plus(other: DecimalNumber): DecimalNumber = DecimalNumber(value + other.value)
     actual operator fun div(other: DecimalNumber): DecimalNumber = DecimalNumber(value.divide(other.value, MathContext.DECIMAL64))
     actual fun pow(other: DecimalNumber): DecimalNumber = DecimalNumber(value.toDouble().pow(other.value.toDouble()))
+
+    actual fun toPlainString(): String = value.stripTrailingZeros().toPlainString()
+    actual override fun toString(): String = value.stripTrailingZeros().toString()
 }
 
 actual fun log10(num: DecimalNumber): DecimalNumber = DecimalNumber(kotlin.math.log10(num.value.toDouble()))

--- a/backend/src/main/kotlin/com/infowings/catalog/common/DecimalNumber.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/common/DecimalNumber.kt
@@ -1,16 +1,18 @@
 package com.infowings.catalog.common
 
 import java.math.BigDecimal
+import java.math.MathContext
 import kotlin.math.pow
 
 actual class DecimalNumber(val value: BigDecimal) {
     actual constructor(value: Double) : this(BigDecimal(value))
     actual constructor(value: Int) : this(BigDecimal(value))
+    actual constructor(value: String) : this(BigDecimal(value))
 
     actual operator fun minus(other: DecimalNumber): DecimalNumber = DecimalNumber(value - other.value)
     actual operator fun times(other: DecimalNumber): DecimalNumber = DecimalNumber(value * other.value)
     actual operator fun plus(other: DecimalNumber): DecimalNumber = DecimalNumber(value + other.value)
-    actual operator fun div(other: DecimalNumber): DecimalNumber = DecimalNumber(value / other.value)
+    actual operator fun div(other: DecimalNumber): DecimalNumber = DecimalNumber(value.divide(other.value, MathContext.DECIMAL64))
     actual fun pow(other: DecimalNumber): DecimalNumber = DecimalNumber(value.toDouble().pow(other.value.toDouble()))
 }
 

--- a/backend/src/main/kotlin/com/infowings/catalog/data/aspect/AspectOVertexExtensions.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/aspect/AspectOVertexExtensions.kt
@@ -77,13 +77,16 @@ class AspectVertex(private val vertex: OVertex) : HistoryAware, OVertex by verte
             vertex["baseType"] = value
         }
 
+    val baseTypeStrict: String
+        get() = baseType ?: throw IllegalStateException("Aspect vertex $this does not have base type")
+
     var name: String
         get() = vertex[ATTR_NAME]
         set(value) {
             vertex[ATTR_NAME] = value
         }
 
-    val measure: Measure<*>?
+    val measure: Measure<DecimalNumber>?
         get() = GlobalMeasureMap[measureName]
 
     var measureName: String?

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectDaoService.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectDaoService.kt
@@ -4,6 +4,7 @@ import com.infowings.catalog.common.*
 import com.infowings.catalog.common.objekt.ObjectCreateRequest
 import com.infowings.catalog.common.objekt.ObjectUpdateRequest
 import com.infowings.catalog.data.aspect.OpenDomain
+import com.infowings.catalog.data.toMeasure
 import com.infowings.catalog.loggerFor
 import com.infowings.catalog.storage.*
 import com.orientechnologies.orient.core.id.ORID
@@ -106,6 +107,7 @@ class ObjectDaoService(private val db: OrientDatabase) {
                 DetailedRootValueViewResponse(
                     rootValue.id,
                     rootValue.toObjectPropertyValue().calculateObjectValueData().toDTO(),
+                    rootValue.measure?.toMeasure()?.symbol,
                     rootValue.description,
                     rootValue.children.map { it.toDetailedAspectPropertyValueResponse() }
                 )
@@ -118,6 +120,7 @@ class ObjectDaoService(private val db: OrientDatabase) {
         return DetailedValueViewResponse(
             this.id,
             this.toObjectPropertyValue().calculateObjectValueData().toDTO(),
+            this.measure?.toMeasure()?.symbol,
             this.description,
             AspectPropertyDataExtended(
                 aspectProperty.id,

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectDaoService.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectDaoService.kt
@@ -105,7 +105,7 @@ class ObjectDaoService(private val db: OrientDatabase) {
             return@transaction rootPropertyValues.map { rootValue ->
                 DetailedRootValueViewResponse(
                     rootValue.id,
-                    rootValue.toObjectPropertyValue().value.toObjectValueData().toDTO(),
+                    rootValue.toObjectPropertyValue().calculateObjectValueData().toDTO(),
                     rootValue.description,
                     rootValue.children.map { it.toDetailedAspectPropertyValueResponse() }
                 )
@@ -117,7 +117,7 @@ class ObjectDaoService(private val db: OrientDatabase) {
         val aspect = aspectProperty.associatedAspect
         return DetailedValueViewResponse(
             this.id,
-            this.toObjectPropertyValue().value.toObjectValueData().toDTO(),
+            this.toObjectPropertyValue().calculateObjectValueData().toDTO(),
             this.description,
             AspectPropertyDataExtended(
                 aspectProperty.id,

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectPropertyValue.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectPropertyValue.kt
@@ -102,7 +102,6 @@ data class ObjectPropertyValue(
     val parentValue: ObjectPropertyValueVertex?,
     val measure: OVertex?
 ) {
-    @Suppress("UNCHECKED_CAST")
     fun calculateObjectValueData(): ObjectValueData {
         val measure = this.measure?.toMeasure() ?: when (aspectProperty) {
             null -> objectProperty.aspect ?: throw IllegalStateException("Object property does not contain aspect")
@@ -112,8 +111,7 @@ data class ObjectPropertyValue(
         val targetValue = value.toObjectValueData()
 
         return if (targetValue is ObjectValueData.DecimalValue && measure != null) {
-            val targetMeasure = measure as Measure<DecimalNumber>
-            ObjectValueData.DecimalValue(targetMeasure.fromBase(DecimalNumber(BigDecimal(targetValue.valueRepr))).value.stripTrailingZeros().toString())
+            ObjectValueData.DecimalValue(measure.fromBase(DecimalNumber(BigDecimal(targetValue.valueRepr))).toString())
         } else {
             targetValue
         }

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectPropertyValue.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectPropertyValue.kt
@@ -112,7 +112,7 @@ data class ObjectPropertyValue(
 
         return if (targetValue is ObjectValueData.DecimalValue && measure != null) {
             val targetMeasure = measure as Measure<DecimalNumber>
-            ObjectValueData.DecimalValue(targetMeasure.fromBase(DecimalNumber(BigDecimal(targetValue.valueRepr))).value.toString())
+            ObjectValueData.DecimalValue(targetMeasure.fromBase(DecimalNumber(BigDecimal(targetValue.valueRepr))).value.stripTrailingZeros().toString())
         } else {
             targetValue
         }

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectPropertyValue.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectPropertyValue.kt
@@ -122,7 +122,7 @@ data class ObjectPropertyValue(
 data class ValueResult(
     private val valueVertex: ObjectPropertyValueVertex,
     val valueDto: ValueDTO,
-    val measureId: String?,
+    val measureSymbol: String?,
     private val objectProperty: ObjectPropertyVertex,
     private val aspectProperty: AspectPropertyVertex?,
     private val parentValue: ObjectPropertyValueVertex?

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectPropertyValue.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectPropertyValue.kt
@@ -102,6 +102,7 @@ data class ObjectPropertyValue(
     val parentValue: ObjectPropertyValueVertex?,
     val measure: OVertex?
 ) {
+    @Suppress("UNCHECKED_CAST")
     fun calculateObjectValueData(): ObjectValueData {
         val measure = this.measure?.toMeasure() ?: when (aspectProperty) {
             null -> objectProperty.aspect ?: throw IllegalStateException("Object property does not contain aspect")

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectPropertyValue.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectPropertyValue.kt
@@ -1,13 +1,11 @@
 package com.infowings.catalog.data.objekt
 
-import com.infowings.catalog.common.LinkValueData
-import com.infowings.catalog.common.ObjectValueData
-import com.infowings.catalog.common.Range
-import com.infowings.catalog.common.ValueDTO
+import com.infowings.catalog.common.*
 import com.infowings.catalog.data.aspect.AspectPropertyVertex
 import com.infowings.catalog.data.aspect.AspectVertex
 import com.infowings.catalog.data.reference.book.ReferenceBookItemVertex
 import com.infowings.catalog.data.subject.SubjectVertex
+import com.infowings.catalog.data.toMeasure
 import com.infowings.catalog.storage.description
 import com.infowings.catalog.storage.id
 import com.orientechnologies.orient.core.id.ORID
@@ -103,7 +101,23 @@ data class ObjectPropertyValue(
     val aspectProperty: AspectPropertyVertex?,
     val parentValue: ObjectPropertyValueVertex?,
     val measure: OVertex?
-)
+) {
+    fun calculateObjectValueData(): ObjectValueData {
+        val measure = this.measure?.toMeasure() ?: when (aspectProperty) {
+            null -> objectProperty.aspect ?: throw IllegalStateException("Object property does not contain aspect")
+            else -> aspectProperty.associatedAspect
+        }.measure
+
+        val targetValue = value.toObjectValueData()
+
+        return if (targetValue is ObjectValueData.DecimalValue && measure != null) {
+            val targetMeasure = measure as Measure<DecimalNumber>
+            ObjectValueData.DecimalValue(targetMeasure.fromBase(DecimalNumber(BigDecimal(targetValue.valueRepr))).value.toString())
+        } else {
+            targetValue
+        }
+    }
+}
 
 data class ValueResult(
     private val valueVertex: ObjectPropertyValueVertex,

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectPropertyValue.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectPropertyValue.kt
@@ -122,7 +122,7 @@ data class ObjectPropertyValue(
 data class ValueResult(
     private val valueVertex: ObjectPropertyValueVertex,
     val valueDto: ValueDTO,
-    val measureSymbol: String?,
+    val measureName: String?,
     private val objectProperty: ObjectPropertyVertex,
     private val aspectProperty: AspectPropertyVertex?,
     private val parentValue: ObjectPropertyValueVertex?

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectService.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectService.kt
@@ -261,13 +261,14 @@ class ObjectService(
     private fun ObjectPropertyValueVertex.toValueResult() = ValueResult(
         this,
         this.toObjectPropertyValue().calculateObjectValueData().toDTO(),
-        this.measure?.toMeasure()?.symbol,
+        this.measure?.toMeasure()?.name,
         this.objectProperty ?: throw IllegalStateException("Object value was created without reference to object property"),
         this.aspectProperty,
         this.parentValue
     )
 
-    private fun ValueResult.toResponse() = ValueChangeResponse(id, valueDto, description, measureSymbol, Reference(objectPropertyId, objectPropertyVersion),
+    private fun ValueResult.toResponse() = ValueChangeResponse(
+        id, valueDto, description, measureName, Reference(objectPropertyId, objectPropertyVersion),
         aspectPropertyId, parentValueId?.let { id -> parentValueVersion?.let { version -> Reference(id, version) } }, version
     )
 

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectService.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectService.kt
@@ -10,6 +10,7 @@ import com.infowings.catalog.data.history.HistoryAware
 import com.infowings.catalog.data.history.HistoryContext
 import com.infowings.catalog.data.history.HistoryService
 import com.infowings.catalog.data.reference.book.ReferenceBookService
+import com.infowings.catalog.data.toMeasure
 import com.infowings.catalog.storage.*
 import com.orientechnologies.orient.core.id.ORID
 
@@ -75,6 +76,7 @@ class ObjectService(
                         ValueTruncated (
                             it.id,
                             it.toObjectPropertyValue().calculateObjectValueData().toDTO(),
+                            it.measure?.toMeasure()?.name,
                             it.description,
                             it.aspectProperty?.id,
                             it.version,
@@ -259,13 +261,13 @@ class ObjectService(
     private fun ObjectPropertyValueVertex.toValueResult() = ValueResult(
         this,
         this.toObjectPropertyValue().calculateObjectValueData().toDTO(),
-        this.measure?.id,
+        this.measure?.toMeasure()?.symbol,
         this.objectProperty ?: throw IllegalStateException("Object value was created without reference to object property"),
         this.aspectProperty,
         this.parentValue
     )
 
-    private fun ValueResult.toResponse() = ValueChangeResponse(id, valueDto, description, measureId, Reference(objectPropertyId, objectPropertyVersion),
+    private fun ValueResult.toResponse() = ValueChangeResponse(id, valueDto, description, measureSymbol, Reference(objectPropertyId, objectPropertyVersion),
         aspectPropertyId, parentValueId?.let { id -> parentValueVersion?.let { version -> Reference(id, version) } }, version
     )
 

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectService.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectService.kt
@@ -74,7 +74,7 @@ class ObjectService(
                     val values = it.values.map {
                         ValueTruncated (
                             it.id,
-                            it.toObjectPropertyValue().value.toObjectValueData().toDTO(),
+                            it.toObjectPropertyValue().calculateObjectValueData().toDTO(),
                             it.description,
                             it.aspectProperty?.id,
                             it.version,
@@ -258,7 +258,7 @@ class ObjectService(
 
     private fun ObjectPropertyValueVertex.toValueResult() = ValueResult(
         this,
-        this.toObjectPropertyValue().value.toObjectValueData().toDTO(),
+        this.toObjectPropertyValue().calculateObjectValueData().toDTO(),
         this.measure?.id,
         this.objectProperty ?: throw IllegalStateException("Object value was created without reference to object property"),
         this.aspectProperty,

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectService.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectService.kt
@@ -564,6 +564,7 @@ class ObjectService(
         deleteObject(id, username, ::removeOrMark)
     }
 
+    @Suppress("UNCHECKED_CAST")
     fun recalculateValue(fromMeasureStr: String, toMeasureStr: String, value: BigDecimal): BigDecimal {
         val fromMeasure = (GlobalMeasureMap[fromMeasureStr] ?: throw RecalculationException("Measure $fromMeasureStr does not exist")) as Measure<DecimalNumber>
         val toMeasure = (GlobalMeasureMap[toMeasureStr] ?: throw RecalculationException("Measure $toMeasureStr does not exist")) as Measure<DecimalNumber>

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectService.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectService.kt
@@ -76,7 +76,7 @@ class ObjectService(
                         ValueTruncated (
                             it.id,
                             it.toObjectPropertyValue().calculateObjectValueData().toDTO(),
-                            it.measure?.toMeasure()?.name,
+                            it.explicitMeasure(),
                             it.description,
                             it.aspectProperty?.id,
                             it.version,
@@ -261,11 +261,14 @@ class ObjectService(
     private fun ObjectPropertyValueVertex.toValueResult() = ValueResult(
         this,
         this.toObjectPropertyValue().calculateObjectValueData().toDTO(),
-        this.measure?.toMeasure()?.name,
+        this.explicitMeasure(),
         this.objectProperty ?: throw IllegalStateException("Object value was created without reference to object property"),
         this.aspectProperty,
         this.parentValue
     )
+
+    private fun ObjectPropertyValueVertex.explicitMeasure() =
+        this.measure?.toMeasure()?.name ?: this.aspectProperty?.associatedAspect?.measureName ?: this.objectProperty?.aspect?.measureName
 
     private fun ValueResult.toResponse() = ValueChangeResponse(
         id, valueDto, description, measureName, Reference(objectPropertyId, objectPropertyVersion),

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectService.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectService.kt
@@ -561,8 +561,8 @@ class ObjectService(
     }
 
     fun recalculateValue(fromMeasureStr: String, toMeasureStr: String, value: DecimalNumber): DecimalNumber {
-        val fromMeasure = (GlobalMeasureMap[fromMeasureStr] ?: throw RecalculationException("Measure $fromMeasureStr does not exist"))
-        val toMeasure = (GlobalMeasureMap[toMeasureStr] ?: throw RecalculationException("Measure $toMeasureStr does not exist"))
+        val fromMeasure = GlobalMeasureMap[fromMeasureStr] ?: throw RecalculationException("Measure $fromMeasureStr does not exist")
+        val toMeasure = GlobalMeasureMap[toMeasureStr] ?: throw RecalculationException("Measure $toMeasureStr does not exist")
 
         val fromMeasureGroup = MeasureMeasureGroupMap.getValue(fromMeasure.name)
         val toMeasureGroup = MeasureMeasureGroupMap.getValue(toMeasure.name)

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectValidator.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectValidator.kt
@@ -185,7 +185,7 @@ class MainObjectValidator(
             throw IllegalArgumentException("Value ${request.value} is not compatible with type $baseType")
         }
 
-        val measureVertex = request.measureId?.let { measureService.findById(it) }
+        val measureVertex = request.measureName?.let { measureService.findMeasure(it) }
 
         val measure = (measureVertex?.toMeasure() ?: when (request.parentValueId) {
             null -> objectPropertyVertex.aspect ?: throw IllegalStateException("Object property has no reference to aspect")
@@ -235,7 +235,15 @@ class MainObjectValidator(
 
         val parentValueVertex = valueVertex.parentValue
 
-        val measure = (valueVertex.measure?.toMeasure() ?: when (parentValueVertex) {
+        val currentValueMeasureVertex = valueVertex.measure
+
+        val valueMeasureVertex = when {
+            request.measureName == null -> currentValueMeasureVertex
+            request.measureName != currentValueMeasureVertex?.toMeasure()?.name -> measureService.findMeasure(request.measureName)
+            else -> currentValueMeasureVertex
+        }
+
+        val measure = (valueMeasureVertex?.toMeasure() ?: when (parentValueVertex) {
             null -> objectPropertyVertex.aspect ?: throw IllegalStateException("Object property has no reference to aspect")
             else -> aspectPropertyVertex?.associatedAspect ?: throw IllegalArgumentException("No aspect property id for non-root value")
         }.measure) as? Measure<DecimalNumber>

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectValidator.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectValidator.kt
@@ -264,16 +264,13 @@ class MainObjectValidator(
     @Suppress("UNCHECKED_CAST")
     private fun validateMeasureInRequest(measureGroup: MeasureGroup<*>?, requestMeasureName: String?): Measure<DecimalNumber>? {
         val measure = when {
-            measureGroup != null && requestMeasureName != null -> {
+            measureGroup != null && requestMeasureName != null ->
                 measureGroup.measureList.find { it.name == requestMeasureName }
                         ?: throw IllegalArgumentException("Measure group for value (${measureGroup.name}) does not have measure $requestMeasureName")
-            }
-            measureGroup != null && requestMeasureName == null -> {
+            measureGroup != null && requestMeasureName == null ->
                 throw IllegalArgumentException("Measure group for value is specified (${measureGroup.name}) but no measure is specified in request")
-            }
-            measureGroup == null && requestMeasureName != null -> {
+            measureGroup == null && requestMeasureName != null ->
                 throw IllegalArgumentException("Measure group for value not specified but request specifies measure $requestMeasureName")
-            }
             else -> null
         }
         return measure as? Measure<DecimalNumber>

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectValidator.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectValidator.kt
@@ -263,7 +263,7 @@ class MainObjectValidator(
             objectPropertyVertex,
             aspectPropertyVertex,
             parentValueVertex,
-            valueVertex.measure
+            valueMeasureVertex
         )
     }
 

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectValidator.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectValidator.kt
@@ -186,7 +186,11 @@ class MainObjectValidator(
         val defaultMeasureGroup =
             valueAspectVertex.measureName?.let { MeasureMeasureGroupMap[it] ?: throw IllegalStateException("No measure group for measure $it") }
 
-        val measure = validateMeasureInRequest(defaultMeasureGroup, request.measureName)
+        val measure = if (request.value == ObjectValueData.NullValue) {
+            if (request.measureName == null) null else throw IllegalArgumentException("Value in request is NullValue, but measure is ${request.measureName}")
+        } else {
+            validateMeasureInRequest(defaultMeasureGroup, request.measureName)
+        }
         val measureVertex = measure?.let { measureService.findMeasure(it.name) ?: throw IllegalStateException("No vertex for measure ${it.name}") }
 
         val dataValue = recalculateValueAccordingToMeasure(request.value, measure)
@@ -227,7 +231,12 @@ class MainObjectValidator(
         val defaultMeasureGroup =
             valueAspectVertex.measureName?.let { MeasureMeasureGroupMap[it] ?: throw IllegalStateException("No measure group for measure $it") }
 
-        val measure = validateMeasureInRequest(defaultMeasureGroup, request.measureName)
+        val measure = if (request.value == ObjectValueData.NullValue) {
+            if (request.measureName == null) null else throw IllegalArgumentException("Value in request is NullValue, but measure is ${request.measureName}")
+        } else {
+            validateMeasureInRequest(defaultMeasureGroup, request.measureName)
+        }
+
         val measureVertex = measure?.let { measureService.findMeasure(it.name) ?: throw IllegalStateException("No vertex for measure ${it.name}") }
 
         val dataValue = recalculateValueAccordingToMeasure(request.value, measure)
@@ -252,6 +261,7 @@ class MainObjectValidator(
             originalValue
         }
 
+    @Suppress("UNCHECKED_CAST")
     private fun validateMeasureInRequest(measureGroup: MeasureGroup<*>?, requestMeasureName: String?): Measure<DecimalNumber>? {
         val measure = when {
             measureGroup != null && requestMeasureName != null -> {

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectValidator.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectValidator.kt
@@ -1,8 +1,6 @@
 package com.infowings.catalog.data.objekt
 
-import com.infowings.catalog.common.BaseType
-import com.infowings.catalog.common.LinkValueData
-import com.infowings.catalog.common.ObjectValueData
+import com.infowings.catalog.common.*
 import com.infowings.catalog.common.objekt.*
 import com.infowings.catalog.data.MeasureService
 import com.infowings.catalog.data.SubjectService
@@ -10,6 +8,7 @@ import com.infowings.catalog.data.aspect.AspectDaoService
 import com.infowings.catalog.data.aspect.AspectDoesNotExist
 import com.infowings.catalog.data.aspect.AspectPropertyDoesNotExist
 import com.infowings.catalog.data.reference.book.ReferenceBookService
+import com.infowings.catalog.data.toMeasure
 import com.infowings.catalog.loggerFor
 import com.infowings.catalog.storage.id
 import com.orientechnologies.orient.core.id.ORecordId
@@ -172,8 +171,7 @@ class MainObjectValidator(
         }
 
         val aspectPropertyVertex = request.aspectPropertyId?.let {
-            aspectDao.findProperty(it)
-                    ?: throw AspectPropertyDoesNotExist(it)
+            aspectDao.findProperty(it) ?: throw AspectPropertyDoesNotExist(it)
         }
 
         val parentValueVertex = request.parentValueId?.let { objectService.findPropertyValueById(it) }
@@ -182,16 +180,27 @@ class MainObjectValidator(
             aspectPropertyVertex?.let { aspectDao.baseType(it) }
         else objectPropertyVertex.let { objectDaoService.baseType(it) }
 
-        val baseType = btStr?.let { BaseType.restoreBaseType(it) }
-        if (!request.value.assignableTo(baseType!!)) {
+        val baseType = btStr?.let { BaseType.restoreBaseType(it) } ?: throw IllegalStateException("Associated aspect has no base type")
+        if (!request.value.assignableTo(baseType)) {
             throw IllegalArgumentException("Value ${request.value} is not compatible with type $baseType")
         }
 
-        val dataValue = request.value
+        val measureVertex = request.measureId?.let { measureService.findById(it) }
+
+        val measure = (measureVertex?.toMeasure() ?: when (request.parentValueId) {
+            null -> objectPropertyVertex.aspect ?: throw IllegalStateException("Object property has no reference to aspect")
+            else -> aspectPropertyVertex?.associatedAspect ?: throw IllegalArgumentException("No aspect property id for non-root value")
+        }.measure) as? Measure<DecimalNumber>
+
+        val dataValue = if (request.value is ObjectValueData.DecimalValue && measure != null) {
+            val valueRepresentation = BigDecimal(request.value.valueRepr)
+            ObjectValueData.DecimalValue(measure.toBase(DecimalNumber(valueRepresentation)).value.toString())
+        } else {
+            request.value
+        }
 
         val value = getObjectValueFromData(dataValue)
 
-        val measureVertex = request.measureId?.let { measureService.findById(it) }
 
         return ValueWriteInfo(value, request.description, objectPropertyVertex, aspectPropertyVertex, parentValueVertex, measureVertex)
     }
@@ -226,7 +235,17 @@ class MainObjectValidator(
 
         val parentValueVertex = valueVertex.parentValue
 
-        val dataValue = request.value
+        val measure = (valueVertex.measure?.toMeasure() ?: when (parentValueVertex) {
+            null -> objectPropertyVertex.aspect ?: throw IllegalStateException("Object property has no reference to aspect")
+            else -> aspectPropertyVertex?.associatedAspect ?: throw IllegalArgumentException("No aspect property id for non-root value")
+        }.measure) as? Measure<DecimalNumber>
+
+        val dataValue = if (request.value is ObjectValueData.DecimalValue && measure != null) {
+            val valueRepresentation = BigDecimal(request.value.valueRepr)
+            ObjectValueData.DecimalValue(measure.toBase(DecimalNumber(valueRepresentation)).value.toString())
+        } else {
+            request.value
+        }
 
         val value = getObjectValueFromData(dataValue)
 

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectValidator.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectValidator.kt
@@ -255,7 +255,7 @@ class MainObjectValidator(
     private fun validateMeasureInRequest(measureGroup: MeasureGroup<*>?, requestMeasureName: String?): Measure<DecimalNumber>? {
         val measure = when {
             measureGroup != null && requestMeasureName != null -> {
-                measureGroup.elementGroupMap[requestMeasureName]
+                measureGroup.measureList.find { it.name == requestMeasureName }
                         ?: throw IllegalArgumentException("Measure group for value (${measureGroup.name}) does not have measure $requestMeasureName")
             }
             measureGroup != null && requestMeasureName == null -> {

--- a/backend/src/main/kotlin/com/infowings/catalog/external/ObjectApi.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/external/ObjectApi.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.json.JSON
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import java.math.BigDecimal
 import java.security.Principal
 
 @RestController
@@ -22,6 +23,21 @@ class ObjectApi(val objectService: ObjectService) {
         val username = principal.name
         logger.debug("Get objects request by $username")
         return ObjectsResponse(objectService.fetch().map { it.toResponse() })
+    }
+
+    @GetMapping("recalculateValue")
+    fun recalculateValue(
+        @RequestParam("from", required = true) fromMeasure: String,
+        @RequestParam("to", required = true) toMeasure: String,
+        @RequestParam("value", required = true) value: String,
+        principal: Principal
+    ): ValueRecalculationResponse {
+        val username = principal.name
+        logger.debug("Recalculate value request by $username")
+        return ValueRecalculationResponse(
+            targetMeasure = toMeasure,
+            value = objectService.recalculateValue(fromMeasure, toMeasure, BigDecimal(value)).stripTrailingZeros().toPlainString()
+        )
     }
 
     @GetMapping("{id}/viewdetails")

--- a/backend/src/main/kotlin/com/infowings/catalog/external/ObjectApi.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/external/ObjectApi.kt
@@ -1,5 +1,6 @@
 package com.infowings.catalog.external
 
+import com.infowings.catalog.common.DecimalNumber
 import com.infowings.catalog.common.DetailedObjectViewResponse
 import com.infowings.catalog.common.ObjectEditDetailsResponse
 import com.infowings.catalog.common.ObjectsResponse
@@ -10,7 +11,6 @@ import kotlinx.serialization.json.JSON
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
-import java.math.BigDecimal
 import java.security.Principal
 
 @RestController
@@ -36,7 +36,7 @@ class ObjectApi(val objectService: ObjectService) {
         logger.debug("Recalculate value request by $username")
         return ValueRecalculationResponse(
             targetMeasure = toMeasure,
-            value = objectService.recalculateValue(fromMeasure, toMeasure, BigDecimal(value)).stripTrailingZeros().toPlainString()
+            value = objectService.recalculateValue(fromMeasure, toMeasure, DecimalNumber(value)).toPlainString()
         )
     }
 

--- a/backend/src/main/kotlin/com/infowings/catalog/search/SuggestionService.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/search/SuggestionService.kt
@@ -51,7 +51,7 @@ class SuggestionService(
         val text = textOrAllWildcard(commonParam?.text)
         return session(database) {
             findMeasureInDb(measureGroupName, text).mapNotNull { it.toMeasure() }
-                .toMutableList()
+                .toMutableList<Measure<*>>()
                 .addAnExactMatchToTheBeginning(commonParam)
                 .addMeasureDescSuggestion(text, MEASURE_VERTEX)
                 .distinct()

--- a/backend/src/test/kotlin/com/infowings/catalog/PingTest.kt
+++ b/backend/src/test/kotlin/com/infowings/catalog/PingTest.kt
@@ -245,6 +245,7 @@ class PingTest {
                 propertyCreateResponse.rootValue.id,
                 ObjectValueData.StringValue("hello"),
                 null,
+                null,
                 propertyCreateResponse.rootValue.version
             ), username
         )

--- a/backend/src/test/kotlin/com/infowings/catalog/data/aspect/update/NotFreeAspectUpdateTest.kt
+++ b/backend/src/test/kotlin/com/infowings/catalog/data/aspect/update/NotFreeAspectUpdateTest.kt
@@ -50,7 +50,7 @@ class NotFreeAspectUpdateTest {
 
     @Test
     fun testChangeBaseTypeHasValue() {
-        createRootValue(125)
+        createRootValue(125, Kilometre.name)
         assertThrows<AspectModificationException> {
             aspectService.save(aspectWithObjectProperty.copy(measure = null, baseType = BaseType.Text.name), username)
         }
@@ -81,7 +81,7 @@ class NotFreeAspectUpdateTest {
 
     @Test
     fun testChangeAspectMeasureOtherGroupHasValue() {
-        createRootValue(125)
+        createRootValue(125, Kilometre.name)
         assertThrows<AspectModificationException> {
             aspectService.save(aspectWithObjectProperty.copy(measure = Litre.name), username)
         }
@@ -152,13 +152,13 @@ class NotFreeAspectUpdateTest {
         aspectLinkedOtherAspect = aspectService.findById(aspectLinkedOtherAspect.id!!)
     }
 
-    private fun createRootValue(value: Int = 0): ValueChangeResponse {
-        val objPropertyValueRequest = ValueCreateRequest.root(ObjectValueData.DecimalValue(value.toString()), null, propertyCreateResponse.id)
+    private fun createRootValue(value: Int, measureName: String?): ValueChangeResponse {
+        val objPropertyValueRequest = ValueCreateRequest(ObjectValueData.DecimalValue(value.toString()), null, propertyCreateResponse.id, measureName)
         return objectService.create(objPropertyValueRequest, username)
     }
 
     private fun createNullRootValue(): ValueChangeResponse {
-        val objPropertyValueRequest = ValueCreateRequest.root(ObjectValueData.NullValue, null, propertyCreateResponse.id)
+        val objPropertyValueRequest = ValueCreateRequest(ObjectValueData.NullValue, null, propertyCreateResponse.id)
         return objectService.create(objPropertyValueRequest, username)
     }
 
@@ -167,7 +167,7 @@ class NotFreeAspectUpdateTest {
             value = ObjectValueData.DecimalValue(value.toString()),
             description = null, objectPropertyId = propertyCreateResponse.id,
             aspectPropertyId = aspectPropertyId,
-            measureId = null,
+            measureName = Second.name,
             parentValueId = parentId
         )
         objectService.create(objPropertyValueRequest, username)

--- a/backend/src/test/kotlin/com/infowings/catalog/data/measure/MeasureRecalculationTest.kt
+++ b/backend/src/test/kotlin/com/infowings/catalog/data/measure/MeasureRecalculationTest.kt
@@ -1,0 +1,114 @@
+package com.infowings.catalog.data.measure
+
+import com.infowings.catalog.common.*
+import com.infowings.catalog.data.objekt.ObjectService
+import com.infowings.catalog.data.objekt.RecalculationException
+import io.kotlintest.Matcher
+import io.kotlintest.Result
+import io.kotlintest.should
+import io.kotlintest.shouldThrow
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import java.math.BigDecimal
+
+@ExtendWith(SpringExtension::class)
+@SpringBootTest
+class MeasureRecalculationTest {
+
+    @Autowired
+    lateinit var objectService: ObjectService
+
+    val beRelativelyEqualTo = relativelyEqualWithDelta(allowedRelativeDelta)
+
+    @Test
+    fun `Recalculation from metre to yard with right parameters results in correct result`() {
+        val metreValue = "10"
+        val expectedYardValue = "10.936133"
+
+        val resultYardValue = objectService.recalculateValue(Metre.name, Yard.name, BigDecimal(metreValue))
+        resultYardValue should beRelativelyEqualTo(expectedYardValue)
+    }
+
+    @Test
+    fun `Recalculation from yard to metre with right parameters results in correct result`() {
+        val yardValue = "10"
+        val expectedMetreValue = "9.144"
+
+        val resultMetreValue = objectService.recalculateValue(Yard.name, Metre.name, BigDecimal(yardValue))
+        resultMetreValue should beRelativelyEqualTo(expectedMetreValue)
+    }
+
+    @Test
+    fun `Recalculation from celsius to fahrenheit with right parameters results in correct result`() {
+        val celsiusValue = "37.7"
+        val expectedFahrenheitValue = "99.86"
+
+        val resultFahrenheitValue = objectService.recalculateValue(Celsius.name, Fahrenheit.name, BigDecimal(celsiusValue))
+        resultFahrenheitValue should beRelativelyEqualTo(expectedFahrenheitValue)
+    }
+
+    @Test
+    fun `Recalculation from fahrenheit to celsius with right parameters results in correct result`() {
+        val fahrenheitValue = "88.42"
+        val expectedCelsiusValue = "31.344444"
+
+        val resultCelsiusValue = objectService.recalculateValue(Fahrenheit.name, Celsius.name, BigDecimal(fahrenheitValue))
+        resultCelsiusValue should beRelativelyEqualTo(expectedCelsiusValue)
+    }
+
+    @Test
+    fun `Recalculation from yard to inch with right parameters results in correct result`() {
+        val yardValue = "50.8"
+        val expectedInchValue = "1828.8"
+
+        val resultInchValue = objectService.recalculateValue(Yard.name, Inch.name, BigDecimal(yardValue))
+        resultInchValue should beRelativelyEqualTo(expectedInchValue)
+    }
+
+    @Test
+    fun `Recalculation from inch to yard with right parameters results in incorrect result`() {
+        val inchValue = "50.8"
+        val expectedYardValue = "1.411111"
+
+        val resultYardValue = objectService.recalculateValue(Inch.name, Yard.name, BigDecimal(inchValue))
+        resultYardValue should beRelativelyEqualTo(expectedYardValue)
+    }
+
+    @Test
+    fun `Recalculation from celsius to yard should result in thrown exception`() {
+        val celsiusValue = "36.6"
+
+        shouldThrow<RecalculationException> {
+            objectService.recalculateValue(Celsius.name, Yard.name, BigDecimal(celsiusValue))
+        }
+    }
+
+}
+
+const val allowedRelativeDelta = "0.0001"
+
+class BigDecimalRelativelyEqualMatcher(relativeDelta: BigDecimal, private val targetValue: BigDecimal) : Matcher<BigDecimal> {
+
+    private val relativeDeltaAbs: BigDecimal = relativeDelta.abs()
+
+    constructor(relativeDelta: String, targetValue: String) : this(BigDecimal(relativeDelta), BigDecimal(targetValue))
+
+    override fun test(value: BigDecimal): Result {
+        val absoluteDelta = value.abs().multiply(relativeDeltaAbs)
+        val upperBound = value.plus(absoluteDelta)
+        val lowerBound = value.minus(absoluteDelta)
+        return Result(
+            targetValue in lowerBound..upperBound,
+            "$targetValue is not in allowed bounds [$lowerBound .. $upperBound] of $value",
+            "$targetValue is too close to $value"
+        )
+    }
+
+}
+
+fun relativelyEqualWithDelta(relativeDelta: String) = { targetValue: String ->
+    BigDecimalRelativelyEqualMatcher(relativeDelta, targetValue)
+}

--- a/backend/src/test/kotlin/com/infowings/catalog/data/measure/MeasureRecalculationTest.kt
+++ b/backend/src/test/kotlin/com/infowings/catalog/data/measure/MeasureRecalculationTest.kt
@@ -28,7 +28,7 @@ class MeasureRecalculationTest {
         val metreValue = "10"
         val expectedYardValue = "10.936133"
 
-        val resultYardValue = objectService.recalculateValue(Metre.name, Yard.name, BigDecimal(metreValue))
+        val resultYardValue = objectService.recalculateValue(Metre.name, Yard.name, DecimalNumber(metreValue))
         resultYardValue should beRelativelyEqualTo(expectedYardValue)
     }
 
@@ -37,7 +37,7 @@ class MeasureRecalculationTest {
         val yardValue = "10"
         val expectedMetreValue = "9.144"
 
-        val resultMetreValue = objectService.recalculateValue(Yard.name, Metre.name, BigDecimal(yardValue))
+        val resultMetreValue = objectService.recalculateValue(Yard.name, Metre.name, DecimalNumber(yardValue))
         resultMetreValue should beRelativelyEqualTo(expectedMetreValue)
     }
 
@@ -46,7 +46,7 @@ class MeasureRecalculationTest {
         val celsiusValue = "37.7"
         val expectedFahrenheitValue = "99.86"
 
-        val resultFahrenheitValue = objectService.recalculateValue(Celsius.name, Fahrenheit.name, BigDecimal(celsiusValue))
+        val resultFahrenheitValue = objectService.recalculateValue(Celsius.name, Fahrenheit.name, DecimalNumber(celsiusValue))
         resultFahrenheitValue should beRelativelyEqualTo(expectedFahrenheitValue)
     }
 
@@ -55,7 +55,7 @@ class MeasureRecalculationTest {
         val fahrenheitValue = "88.42"
         val expectedCelsiusValue = "31.344444"
 
-        val resultCelsiusValue = objectService.recalculateValue(Fahrenheit.name, Celsius.name, BigDecimal(fahrenheitValue))
+        val resultCelsiusValue = objectService.recalculateValue(Fahrenheit.name, Celsius.name, DecimalNumber(fahrenheitValue))
         resultCelsiusValue should beRelativelyEqualTo(expectedCelsiusValue)
     }
 
@@ -64,7 +64,7 @@ class MeasureRecalculationTest {
         val yardValue = "50.8"
         val expectedInchValue = "1828.8"
 
-        val resultInchValue = objectService.recalculateValue(Yard.name, Inch.name, BigDecimal(yardValue))
+        val resultInchValue = objectService.recalculateValue(Yard.name, Inch.name, DecimalNumber(yardValue))
         resultInchValue should beRelativelyEqualTo(expectedInchValue)
     }
 
@@ -73,7 +73,7 @@ class MeasureRecalculationTest {
         val inchValue = "50.8"
         val expectedYardValue = "1.411111"
 
-        val resultYardValue = objectService.recalculateValue(Inch.name, Yard.name, BigDecimal(inchValue))
+        val resultYardValue = objectService.recalculateValue(Inch.name, Yard.name, DecimalNumber(inchValue))
         resultYardValue should beRelativelyEqualTo(expectedYardValue)
     }
 
@@ -82,7 +82,7 @@ class MeasureRecalculationTest {
         val celsiusValue = "36.6"
 
         shouldThrow<RecalculationException> {
-            objectService.recalculateValue(Celsius.name, Yard.name, BigDecimal(celsiusValue))
+            objectService.recalculateValue(Celsius.name, Yard.name, DecimalNumber(celsiusValue))
         }
     }
 
@@ -90,16 +90,17 @@ class MeasureRecalculationTest {
 
 const val allowedRelativeDelta = "0.0001"
 
-class BigDecimalRelativelyEqualMatcher(relativeDelta: BigDecimal, private val targetValue: BigDecimal) : Matcher<BigDecimal> {
+class DecimalNumberRelativelyEqualMatcher(relativeDelta: BigDecimal, private val targetValue: BigDecimal) : Matcher<DecimalNumber> {
 
     private val relativeDeltaAbs: BigDecimal = relativeDelta.abs()
 
     constructor(relativeDelta: String, targetValue: String) : this(BigDecimal(relativeDelta), BigDecimal(targetValue))
 
-    override fun test(value: BigDecimal): Result {
-        val absoluteDelta = value.abs().multiply(relativeDeltaAbs)
-        val upperBound = value.plus(absoluteDelta)
-        val lowerBound = value.minus(absoluteDelta)
+    override fun test(value: DecimalNumber): Result {
+        val bigDecimalValue = value.value
+        val absoluteDelta = bigDecimalValue.abs().multiply(relativeDeltaAbs)
+        val upperBound = bigDecimalValue.plus(absoluteDelta)
+        val lowerBound = bigDecimalValue.minus(absoluteDelta)
         return Result(
             targetValue in lowerBound..upperBound,
             "$targetValue is not in allowed bounds [$lowerBound .. $upperBound] of $value",
@@ -110,5 +111,5 @@ class BigDecimalRelativelyEqualMatcher(relativeDelta: BigDecimal, private val ta
 }
 
 fun relativelyEqualWithDelta(relativeDelta: String) = { targetValue: String ->
-    BigDecimalRelativelyEqualMatcher(relativeDelta, targetValue)
+    DecimalNumberRelativelyEqualMatcher(relativeDelta, targetValue)
 }

--- a/backend/src/test/kotlin/com/infowings/catalog/data/measure/ValueEditingMeasureValidationTest.kt
+++ b/backend/src/test/kotlin/com/infowings/catalog/data/measure/ValueEditingMeasureValidationTest.kt
@@ -28,6 +28,7 @@ import org.springframework.web.util.NestedServletException
 
 @ExtendWith(SpringExtension::class)
 @SpringBootTest
+@Suppress("UnsafeCallOnNullableType")
 class ValueEditingMeasureValidationTest {
 
     @Autowired

--- a/backend/src/test/kotlin/com/infowings/catalog/data/measure/ValueEditingMeasureValidationTest.kt
+++ b/backend/src/test/kotlin/com/infowings/catalog/data/measure/ValueEditingMeasureValidationTest.kt
@@ -1,0 +1,152 @@
+package com.infowings.catalog.data.measure
+
+import com.infowings.catalog.common.*
+import com.infowings.catalog.common.objekt.*
+import com.infowings.catalog.storage.OrientClass
+import com.infowings.catalog.storage.OrientDatabase
+import com.infowings.catalog.storage.transaction
+import io.kotlintest.should
+import io.kotlintest.shouldThrow
+import kotlinx.serialization.json.JSON
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+import org.springframework.web.util.NestedServletException
+
+@ExtendWith(SpringExtension::class)
+@SpringBootTest
+class ValueEditingMeasureValidationTest {
+
+    @Autowired
+    lateinit var db: OrientDatabase
+
+    @Autowired
+    lateinit var webApplicationContext: WebApplicationContext
+
+    private lateinit var mockMvc: MockMvc
+
+    private val authorities = SecurityMockMvcRequestPostProcessors.user("admin").authorities(SimpleGrantedAuthority("ADMIN"))
+
+    private lateinit var knetSubject: SubjectData
+    private lateinit var aspectHeight: AspectData
+    private lateinit var tubeObject: ObjectChangeResponse
+    private lateinit var tubeObjectHeightProperty: PropertyCreateResponse
+
+    @BeforeEach
+    fun initializeData() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .apply<DefaultMockMvcBuilder>(SecurityMockMvcConfigurers.springSecurity())
+            .build()
+
+        val subjectDataRequestResult = mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/subject/create")
+                .with(authorities)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(JSON.stringify(SubjectData(null, "Knowledge Net Demo", 0, null, false)))
+        ).andReturn()
+        knetSubject = JSON.parse(subjectDataRequestResult.response.contentAsString)
+
+        val aspectHeightRequestResult = mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/aspect/create")
+                .with(authorities)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(JSON.stringify(AspectData(name = "Height", measure = Millimetre.name, baseType = BaseType.Decimal.name)))
+        ).andReturn()
+        aspectHeight = JSON.parse(aspectHeightRequestResult.response.contentAsString)
+
+        val tubeObjectRequestResult = mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/objects/create")
+                .with(authorities)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(JSON.stringify(ObjectCreateRequest("Tube", null, knetSubject.id!!)))
+        ).andReturn()
+        tubeObject = JSON.parse(tubeObjectRequestResult.response.contentAsString)
+
+        val tubeObjectPropertyRequestResult = mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/objects/createProperty")
+                .with(authorities)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(JSON.stringify(PropertyCreateRequest(tubeObject.id, null, null, aspectHeight.id!!)))
+        ).andReturn()
+        tubeObjectHeightProperty = JSON.parse(tubeObjectPropertyRequestResult.response.contentAsString)
+        tubeObject = tubeObject.copy(version = tubeObjectHeightProperty.obj.version)
+    }
+
+    @Test
+    fun `Create value that requires measure without measure triggers exception`() {
+        val exception = shouldThrow<NestedServletException> {
+            mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/objects/updateValue")
+                    .with(authorities)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        JSON.stringify(
+                            ValueUpdateRequest(
+                                tubeObjectHeightProperty.rootValue.id,
+                                ObjectValueData.DecimalValue("42"),
+                                null,
+                                null,
+                                tubeObjectHeightProperty.rootValue.version
+                            ).toDTO()
+                        )
+                    )
+            )
+        }
+        exception.cause should { it != null && it is IllegalArgumentException }
+    }
+
+    @Test
+    fun `Create value that requires measure with measure from another group triggers exception`() {
+        val exception = shouldThrow<NestedServletException> {
+            mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/objects/updateValue")
+                    .with(authorities)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        JSON.stringify(
+                            ValueUpdateRequest(
+                                tubeObjectHeightProperty.rootValue.id,
+                                ObjectValueData.DecimalValue("42"),
+                                Ampere.name,
+                                null,
+                                tubeObjectHeightProperty.rootValue.version
+                            ).toDTO()
+                        )
+                    )
+            )
+        }
+        exception.cause should { it != null && it is IllegalArgumentException }
+    }
+
+    @AfterEach
+    fun tearDownAllVertices() {
+        transaction(db) {
+            db.command("DELETE VERTEX ${OrientClass.ASPECT.extName}") {}
+            db.command("DELETE VERTEX ${OrientClass.ASPECT_PROPERTY.extName}") {}
+            db.command("DELETE VERTEX ${OrientClass.SUBJECT.extName}") {}
+            db.command("DELETE VERTEX ${OrientClass.OBJECT.extName}") {}
+            db.command("DELETE VERTEX ${OrientClass.OBJECT_PROPERTY.extName}") {}
+            db.command("DELETE VERTEX ${OrientClass.OBJECT_VALUE.extName}") {}
+            db.command("DELETE VERTEX ${OrientClass.REFBOOK_ITEM.extName}") {}
+            db.command("DELETE VERTEX ${OrientClass.HISTORY_ADD_LINK.extName}") {}
+            db.command("DELETE VERTEX ${OrientClass.HISTORY_ELEMENT.extName}") {}
+            db.command("DELETE VERTEX ${OrientClass.HISTORY_EVENT.extName}") {}
+            db.command("DELETE VERTEX ${OrientClass.HISTORY_REMOVE_LINK.extName}") {}
+
+        }
+    }
+
+}

--- a/backend/src/test/kotlin/com/infowings/catalog/data/objekt/ObjectDaoTest.kt
+++ b/backend/src/test/kotlin/com/infowings/catalog/data/objekt/ObjectDaoTest.kt
@@ -27,6 +27,7 @@ import kotlin.test.fail
 
 @ExtendWith(SpringExtension::class)
 @SpringBootTest
+@Suppress("MagicNumber", "StringLiteralDuplication")
 class ObjectDaoTest {
     @Autowired
     private lateinit var db: OrientDatabase

--- a/backend/src/test/kotlin/com/infowings/catalog/data/objekt/ObjectDaoTest.kt
+++ b/backend/src/test/kotlin/com/infowings/catalog/data/objekt/ObjectDaoTest.kt
@@ -182,13 +182,17 @@ class ObjectDaoTest {
             description = null,
             objectPropertyId = createdProperty.id
         )
-        val valueInfo = validator.checkedForCreation(valueRequest)
-        val createdValue = createObjectPropertyValue(valueInfo)
 
-        assertEquals(ScalarTypeTag.INTEGER, createdValue.typeTag, "type tag must be integer")
-        assertNotNull(createdValue.intValue, "int value must be non-null")
-        assertTrue(createdValue.strValue == null, "str type must be null")
-        assertEquals(123, createdValue.intValue, "int value must be 123")
+        val createdValue = transaction(db) {
+            val valueInfo = validator.checkedForCreation(valueRequest)
+            val result = createObjectPropertyValue(valueInfo)
+
+            assertEquals(ScalarTypeTag.INTEGER, result.typeTag, "type tag must be integer")
+            assertNotNull(result.intValue, "int value must be non-null")
+            assertTrue(result.strValue == null, "str type must be null")
+            assertEquals(123, result.intValue, "int value must be 123")
+            result
+        }
 
 
         val propertyOfValue = transaction(db) { createdValue.objectProperty }
@@ -230,14 +234,17 @@ class ObjectDaoTest {
         val propertyInfo = validator.checkedForCreation(propertyRequest)
         val createdProperty = createObjectProperty(propertyInfo)
 
-        val valueRequest = ValueCreateRequest.root(value = ObjectValueData.StringValue("some value"), description = null, objectPropertyId = createdProperty.id)
-        val valueInfo = validator.checkedForCreation(valueRequest)
-        val createdValue = createObjectPropertyValue(valueInfo)
+        val valueRequest = ValueCreateRequest(ObjectValueData.StringValue("some value"), null, createdProperty.id)
 
-        assertEquals(ScalarTypeTag.STRING, createdValue.typeTag, "type tag must be string")
-        assertNotNull(createdValue.strValue, "str value must be non-null")
-        assertTrue(createdValue.intValue == null, "int value must be null")
-        assertEquals("some value", createdValue.strValue, "str value must be correct")
+        transaction(db) {
+            val valueInfo = validator.checkedForCreation(valueRequest)
+            val createdValue = createObjectPropertyValue(valueInfo)
+
+            assertEquals(ScalarTypeTag.STRING, createdValue.typeTag, "type tag must be string")
+            assertNotNull(createdValue.strValue, "str value must be non-null")
+            assertTrue(createdValue.intValue == null, "int value must be null")
+            assertEquals("some value", createdValue.strValue, "str value must be correct")
+        }
     }
 
     @Test
@@ -392,10 +399,10 @@ class ObjectDaoTest {
         val objVertex = createObject(ObjectCreateRequest(randomName(), sampleDescription, subject.id))
         val aspectVertex = aspectDao.find(complexAspect.id!!)
         val objPropertyVertex = createObjectProperty(PropertyWriteInfo("propName", null, objVertex, aspectVertex!!))
-        val valueRequest1 = ValueCreateRequest(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id)
+        val valueRequest1 = ValueCreateRequest(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id, Kilometre.name)
         val objPropValueResponse = objectService.create(valueRequest1, username)
         val updatedValueResponse = objectService.update(
-            ValueUpdateRequest(objPropValueResponse.id, ObjectValueData.DecimalValue("1123.4"), null, objPropValueResponse.version),
+            ValueUpdateRequest(objPropValueResponse.id, ObjectValueData.DecimalValue("1123.4"), Kilometre.name, null, objPropValueResponse.version),
             username
         )
 
@@ -408,13 +415,21 @@ class ObjectDaoTest {
         val aspectVertex = aspectDao.find(complexAspect.id!!)
         val objPropertyVertex = createObjectProperty(PropertyWriteInfo("propName", null, objVertex, aspectVertex!!))
 
-        val valueRequest1 = ValueCreateRequest.root(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id)
+        val valueRequest1 = ValueCreateRequest(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id, Kilometre.name)
         val objPropValueResponse = objectService.create(valueRequest1, username)
 
-        val valueRequest2 = ValueCreateRequest.root(ObjectValueData.DecimalValue("234.5"), null, objPropertyVertex.id)
+        val valueRequest2 = ValueCreateRequest(ObjectValueData.DecimalValue("234.5"), null, objPropertyVertex.id, Kilometre.name)
         objectService.create(valueRequest2, username)
 
-        objectService.update(ValueUpdateRequest(objPropValueResponse.id, ObjectValueData.DecimalValue("234.5"), null, objPropValueResponse.version), username)
+        objectService.update(
+            ValueUpdateRequest(
+                objPropValueResponse.id,
+                ObjectValueData.DecimalValue("234.5"),
+                Kilometre.name,
+                null,
+                objPropValueResponse.version
+            ), username
+        )
     }
 
     @Test
@@ -422,7 +437,7 @@ class ObjectDaoTest {
         val objVertex = createObject(ObjectCreateRequest(randomName(), sampleDescription, subject.id))
         val aspectVertex = aspectDao.find(complexAspect.id!!)
         val objPropertyVertex = createObjectProperty(PropertyWriteInfo("propName", null, objVertex, aspectVertex!!))
-        val valueRequest = ValueCreateRequest.root(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id)
+        val valueRequest = ValueCreateRequest(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id, Kilometre.name)
         val objPropValueResponse = objectService.create(valueRequest, username)
 
         val subvalueIds = dao.getSubValues(objPropValueResponse.id).map { it.id }
@@ -434,9 +449,9 @@ class ObjectDaoTest {
         val objVertex = createObject(ObjectCreateRequest(randomName(), sampleDescription, subject.id))
         val aspectVertex = aspectDao.find(complexAspect.id!!)
         val objPropertyVertex = createObjectProperty(PropertyWriteInfo("propName", null, objVertex, aspectVertex!!))
-        val valueRequest1 = ValueCreateRequest.root(value = ObjectValueData.DecimalValue("123.4"), description = null, objectPropertyId = objPropertyVertex.id)
+        val valueRequest1 = ValueCreateRequest(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id, Kilometre.name)
         val objPropValueResponse1 = objectService.create(valueRequest1, username)
-        val valueRequest2 = ValueCreateRequest.root(value = ObjectValueData.DecimalValue("234.5"), description = null, objectPropertyId = objPropertyVertex.id)
+        val valueRequest2 = ValueCreateRequest(ObjectValueData.DecimalValue("234.5"), null, objPropertyVertex.id, Kilometre.name)
         val objPropValueResponse2 = objectService.create(valueRequest2, username)
 
         val subvalueIds1 = dao.getSubValues(objPropValueResponse1.id).map { it.id }
@@ -451,14 +466,14 @@ class ObjectDaoTest {
         val objVertex = createObject(ObjectCreateRequest(randomName(), sampleDescription, subject.id))
         val aspectVertex = aspectDao.find(complexAspect.id!!)
         val objPropertyVertex = createObjectProperty(PropertyWriteInfo("propName", null, objVertex, aspectVertex!!))
-        val valueRequest1 = ValueCreateRequest.root(value = ObjectValueData.DecimalValue("123.4"), description = null, objectPropertyId = objPropertyVertex.id)
+        val valueRequest1 = ValueCreateRequest(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id, Kilometre.name)
         val objPropValueResponse1 = objectService.create(valueRequest1, username)
         val valueRequest2 = ValueCreateRequest(
             value = ObjectValueData.StringValue("hello2"),
             description = null,
             objectPropertyId = objPropertyVertex.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            measureId = null,
             parentValueId = objPropValueResponse1.id
         )
         val objPropValueResponse2 = objectService.create(valueRequest2, username)
@@ -475,15 +490,15 @@ class ObjectDaoTest {
         val aspectVertex = aspectDao.find(complexAspect.id!!)
         val objPropertyVertex = createObjectProperty(PropertyWriteInfo("propName", null, objVertex, aspectVertex!!))
 
-        val valueRequest1 = ValueCreateRequest(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id)
+        val valueRequest1 = ValueCreateRequest(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id, Kilometre.name)
         val objPropValueResponse1 = objectService.create(valueRequest1, username)
 
         val valueRequest2 = ValueCreateRequest(
             value = ObjectValueData.StringValue("hello2"),
             description = null,
             objectPropertyId = objPropertyVertex.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            measureId = null,
             parentValueId = objPropValueResponse1.id
         )
         val objPropValue2 = objectService.create(valueRequest2, username)
@@ -492,8 +507,8 @@ class ObjectDaoTest {
             value = ObjectValueData.StringValue("hello3"),
             description = null,
             objectPropertyId = objPropertyVertex.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            measureId = null,
             parentValueId = objPropValueResponse1.id
         )
         val objPropValue3 = objectService.create(valueRequest3, username)
@@ -511,15 +526,15 @@ class ObjectDaoTest {
         val objVertex = createObject(ObjectCreateRequest("obj", sampleDescription, subject.id))
         val aspectVertex = aspectDao.find(complexAspect.id!!)
         val objPropertyVertex = createObjectProperty(PropertyWriteInfo("propName", null, objVertex, aspectVertex!!))
-        val valueRequest1 = ValueCreateRequest.root(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id)
+        val valueRequest1 = ValueCreateRequest(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id, Kilometre.name)
 
         val objPropValueResponse1 = objectService.create(valueRequest1, username)
         val valueRequest2 = ValueCreateRequest(
             value = ObjectValueData.StringValue("hello"),
             description = null,
             objectPropertyId = objPropertyVertex.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            measureId = null,
             parentValueId = objPropValueResponse1.id
         )
         val objPropValueResponse2 = objectService.create(valueRequest2, username)
@@ -527,8 +542,8 @@ class ObjectDaoTest {
             value = ObjectValueData.StringValue("hello2"),
             description = null,
             objectPropertyId = objPropertyVertex.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            measureId = null,
             parentValueId = objPropValueResponse2.id
         )
         val objPropValueResponse3 = objectService.create(valueRequest3, username)
@@ -536,8 +551,8 @@ class ObjectDaoTest {
             value = ObjectValueData.StringValue("hello3"),
             description = null,
             objectPropertyId = objPropertyVertex.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            measureId = null,
             parentValueId = objPropValueResponse2.id
         )
         val objPropValue4 = objectService.create(valueRequest4, username)
@@ -557,7 +572,7 @@ class ObjectDaoTest {
         val objVertex = createObject(ObjectCreateRequest(randomName(), sampleDescription, subject.id))
         val aspectVertex = aspectDao.find(complexAspect.id!!)
         val objPropertyVertex = createObjectProperty(PropertyWriteInfo("propName", null, objVertex, aspectVertex!!))
-        val valueRequest = ValueCreateRequest(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id)
+        val valueRequest = ValueCreateRequest(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id, Kilometre.name)
         val objPropValueResponse = objectService.create(valueRequest, username)
 
         val valueIds = dao.valuesOfProperty(objPropertyVertex.id).map { it.id }
@@ -569,9 +584,9 @@ class ObjectDaoTest {
         val objVertex = createObject(ObjectCreateRequest(randomName(), sampleDescription, subject.id))
         val aspectVertex = aspectDao.find(complexAspect.id!!)
         val objPropertyVertex = createObjectProperty(PropertyWriteInfo("propName", null, objVertex, aspectVertex!!))
-        val valueRequest1 = ValueCreateRequest.root(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id)
+        val valueRequest1 = ValueCreateRequest(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id, Kilometre.name)
         val objPropValueResponse1 = objectService.create(valueRequest1, username)
-        val valueRequest2 = ValueCreateRequest.root(ObjectValueData.DecimalValue("234.5"), null, objPropertyVertex.id)
+        val valueRequest2 = ValueCreateRequest(ObjectValueData.DecimalValue("234.5"), null, objPropertyVertex.id, Kilometre.name)
         val objPropValueResponse2 = objectService.create(valueRequest2, username)
 
         val valueIds = dao.valuesOfProperty(objPropertyVertex.id).map { it.id }
@@ -583,14 +598,14 @@ class ObjectDaoTest {
         val objVertex = createObject(ObjectCreateRequest(randomName(), sampleDescription, subject.id))
         val aspectVertex = aspectDao.find(complexAspect.id!!)
         val objPropertyVertex = createObjectProperty(PropertyWriteInfo("propName", null, objVertex, aspectVertex!!))
-        val valueRequest1 = ValueCreateRequest.root(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id)
+        val valueRequest1 = ValueCreateRequest(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id, Kilometre.name)
         val objPropValueResponse1 = objectService.create(valueRequest1, username)
         val valueRequest2 = ValueCreateRequest(
             value = ObjectValueData.StringValue("hello2"),
             description = null,
             objectPropertyId = objPropertyVertex.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            measureId = null,
             parentValueId = objPropValueResponse1.id
         )
         val objPropValueResponse2 = objectService.create(valueRequest2, username)
@@ -604,15 +619,15 @@ class ObjectDaoTest {
         val objVertex = createObject(ObjectCreateRequest(randomName(), sampleDescription, subject.id))
         val aspectVertex = aspectDao.find(complexAspect.id!!)
         val objPropertyVertex = createObjectProperty(PropertyWriteInfo("propName", null, objVertex, aspectVertex!!))
-        val valueRequest1 = ValueCreateRequest(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id)
+        val valueRequest1 = ValueCreateRequest(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id, Kilometre.name)
 
         val objPropValueResponse1 = objectService.create(valueRequest1, username)
         val valueRequest2 = ValueCreateRequest(
             value = ObjectValueData.StringValue("hello2"),
             description = null,
             objectPropertyId = objPropertyVertex.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            measureId = null,
             parentValueId = objPropValueResponse1.id
         )
         val objPropValueResponse2 = objectService.create(valueRequest2, username)
@@ -620,8 +635,8 @@ class ObjectDaoTest {
             value = ObjectValueData.StringValue("hello3"),
             description = null,
             objectPropertyId = objPropertyVertex.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            measureId = null,
             parentValueId = objPropValueResponse1.id
         )
         val objPropValueResponse3 = objectService.create(valueRequest3, username)
@@ -635,14 +650,14 @@ class ObjectDaoTest {
         val objVertex = createObject(ObjectCreateRequest(randomName(), sampleDescription, subject.id))
         val aspectVertex = aspectDao.find(complexAspect.id!!)
         val objPropertyVertex = createObjectProperty(PropertyWriteInfo("propName", null, objVertex, aspectVertex!!))
-        val valueRequest1 = ValueCreateRequest.root(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id)
+        val valueRequest1 = ValueCreateRequest(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id, Kilometre.name)
         val objPropValueResponse1 = objectService.create(valueRequest1, username)
         val valueRequest2 = ValueCreateRequest(
             value = ObjectValueData.StringValue("hello2"),
             description = null,
             objectPropertyId = objPropertyVertex.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            measureId = null,
             parentValueId = objPropValueResponse1.id
         )
         val objPropValueResponse2 = objectService.create(valueRequest2, username)
@@ -650,8 +665,8 @@ class ObjectDaoTest {
             value = ObjectValueData.StringValue("hello3"),
             description = null,
             objectPropertyId = objPropertyVertex.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            measureId = null,
             parentValueId = objPropValueResponse2.id
         )
         val objPropValueResponse3 = objectService.create(valueRequest3, username)
@@ -659,8 +674,8 @@ class ObjectDaoTest {
             value = ObjectValueData.StringValue("hello4"),
             description = null,
             objectPropertyId = objPropertyVertex.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            measureId = null,
             parentValueId = objPropValueResponse2.id
         )
         val objPropValue4 = objectService.create(valueRequest4, username)
@@ -674,12 +689,12 @@ class ObjectDaoTest {
         val objVertex = createObject(ObjectCreateRequest(randomName(), sampleDescription, subject.id))
         val aspectVertex = aspectDao.find(complexAspect.id!!)
         val objPropertyVertex1 = createObjectProperty(PropertyWriteInfo("propName", null, objVertex, aspectVertex!!))
-        val valueRequest1 = ValueCreateRequest.root(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex1.id)
+        val valueRequest1 = ValueCreateRequest(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex1.id, Kilometre.name)
         val objPropValueResponse1 = objectService.create(valueRequest1, username)
 
         val objPropertyVertex2 = createObjectProperty(PropertyWriteInfo("propName2", null, objVertex, aspectVertex))
 
-        val valueRequest2 = ValueCreateRequest.root(ObjectValueData.DecimalValue("234.5"), null, objPropertyVertex2.id)
+        val valueRequest2 = ValueCreateRequest(ObjectValueData.DecimalValue("234.5"), null, objPropertyVertex2.id, Kilometre.name)
         objectService.create(valueRequest2, username)
 
         val valueIds = dao.valuesOfProperty(objPropertyVertex1.id).map { it.id }
@@ -691,7 +706,7 @@ class ObjectDaoTest {
         val objVertex = createObject(ObjectCreateRequest(randomName(), sampleDescription, subject.id))
         val aspectVertex = aspectDao.find(complexAspect.id!!)
         val objPropertyVertex = createObjectProperty(PropertyWriteInfo("propName", null, objVertex, aspectVertex!!))
-        val valueRequest = ValueCreateRequest(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id)
+        val valueRequest = ValueCreateRequest(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id, Kilometre.name)
         val objPropValueResponse = objectService.create(valueRequest, username)
 
         val between = dao.valuesBetween(setOf(ORecordId(objPropValueResponse.id)), setOf(ORecordId(objPropValueResponse.id)))
@@ -704,10 +719,10 @@ class ObjectDaoTest {
         val aspectVertex = aspectDao.find(complexAspect.id!!)
         val objPropertyVertex = createObjectProperty(PropertyWriteInfo("propName", null, objVertex, aspectVertex!!))
 
-        val valueRequest1 = ValueCreateRequest.root(ObjectValueData.DecimalValue("12.3"), null, objPropertyVertex.id)
+        val valueRequest1 = ValueCreateRequest(ObjectValueData.DecimalValue("12.3"), null, objPropertyVertex.id, Kilometre.name)
         val objPropValueResponse1 = objectService.create(valueRequest1, username)
 
-        val valueRequest2 = ValueCreateRequest.root(value = ObjectValueData.DecimalValue("13.4"), description = null, objectPropertyId = objPropertyVertex.id)
+        val valueRequest2 = ValueCreateRequest(ObjectValueData.DecimalValue("13.4"), null, objPropertyVertex.id, Kilometre.name)
         val objPropValueResponse2 = objectService.create(valueRequest2, username)
 
         val between1 = dao.valuesBetween(setOf(ORecordId(objPropValueResponse1.id)), setOf(ORecordId(objPropValueResponse2.id)))
@@ -722,15 +737,15 @@ class ObjectDaoTest {
         val aspectVertex = aspectDao.find(complexAspect.id!!)
         val objPropertyVertex = createObjectProperty(PropertyWriteInfo("propName", null, objVertex, aspectVertex!!))
 
-        val valueRequest1 = ValueCreateRequest(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id)
+        val valueRequest1 = ValueCreateRequest(ObjectValueData.DecimalValue("123.4"), null, objPropertyVertex.id, Kilometre.name)
         val objPropValueResponse1 = objectService.create(valueRequest1, username)
 
         val valueRequest2 = ValueCreateRequest(
             value = ObjectValueData.StringValue("hello2"),
             description = null,
             objectPropertyId = objPropertyVertex.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            measureId = null,
             parentValueId = objPropValueResponse1.id
         )
         val objPropValueResponse2 = objectService.create(valueRequest2, username)
@@ -747,15 +762,15 @@ class ObjectDaoTest {
         val aspectVertex = aspectDao.find(complexAspect.id!!)
         val objPropertyVertex = createObjectProperty(PropertyWriteInfo("propName", null, objVertex, aspectVertex!!))
 
-        val valueRequest1 = ValueCreateRequest(ObjectValueData.DecimalValue("12.3"), null, objPropertyVertex.id)
+        val valueRequest1 = ValueCreateRequest(ObjectValueData.DecimalValue("12.3"), null, objPropertyVertex.id, Kilometre.name)
         val objPropValueResponse1 = objectService.create(valueRequest1, username)
 
         val valueRequest2 = ValueCreateRequest(
             value = ObjectValueData.StringValue("hello2"),
             description = null,
             objectPropertyId = objPropertyVertex.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            measureId = null,
             parentValueId = objPropValueResponse1.id
         )
         val objPropValueResponse2 = objectService.create(valueRequest2, username)
@@ -763,8 +778,8 @@ class ObjectDaoTest {
             value = ObjectValueData.StringValue("hello3"),
             description = null,
             objectPropertyId = objPropertyVertex.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            measureId = null,
             parentValueId = objPropValueResponse1.id
         )
         val objPropValueResponse3 = objectService.create(valueRequest3, username)
@@ -793,15 +808,15 @@ class ObjectDaoTest {
         val aspectVertex = aspectDao.find(complexAspect.id!!)
         val objPropertyVertex = createObjectProperty(PropertyWriteInfo("propName", null, objVertex, aspectVertex!!))
 
-        val valueRequest1 = ValueCreateRequest.root(ObjectValueData.DecimalValue("12.3"), null, objPropertyVertex.id)
+        val valueRequest1 = ValueCreateRequest(ObjectValueData.DecimalValue("12.3"), null, objPropertyVertex.id, Kilometre.name)
         val objPropValueResponse1 = objectService.create(valueRequest1, username)
 
         val valueRequest2 = ValueCreateRequest(
             value = ObjectValueData.StringValue("hello2"),
             description = null,
             objectPropertyId = objPropertyVertex.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            measureId = null,
             parentValueId = objPropValueResponse1.id
         )
         val objPropValueResponse2 = objectService.create(valueRequest2, username)
@@ -810,8 +825,8 @@ class ObjectDaoTest {
             value = ObjectValueData.StringValue("hello3"),
             description = null,
             objectPropertyId = objPropertyVertex.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            measureId = null,
             parentValueId = objPropValueResponse2.id
         )
         val objPropValueResponse3 = objectService.create(valueRequest3, username)
@@ -820,8 +835,8 @@ class ObjectDaoTest {
             value = ObjectValueData.StringValue("hello4"),
             description = null,
             objectPropertyId = objPropertyVertex.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            measureId = null,
             parentValueId = objPropValueResponse2.id
         )
         val objPropValueResponse4 = objectService.create(valueRequest4, username)
@@ -848,8 +863,8 @@ class ObjectDaoTest {
             value = ObjectValueData.IntegerValue(123, null),
             description = null,
             objectPropertyId = objPropertyVertex.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            measureId = null,
             parentValueId = null
         )
         val objPropValue = createObjectPropertyValue(ValueWriteInfo(ObjectValue.IntegerValue(123, null), null, objPropertyVertex, null, null, null))

--- a/backend/src/test/kotlin/com/infowings/catalog/data/objekt/ObjectHistoryTest.kt
+++ b/backend/src/test/kotlin/com/infowings/catalog/data/objekt/ObjectHistoryTest.kt
@@ -297,8 +297,7 @@ class ObjectHistoryTest {
         objectName: String,
         objectDescription: String,
         value: ObjectValueData,
-        aspectId: String,
-        measureId: String? = null
+        aspectId: String
     ): PreparedValueInfo {
         val objectCreateResponse = createObject(objectName, objectDescription)
 
@@ -307,7 +306,7 @@ class ObjectHistoryTest {
 
         val factsBefore: Set<HistoryFact> = historyService.getAll().toSet()
 
-        val valueRequest = ValueUpdateRequest(propertyCreateResponse.rootValue.id, value, null, propertyCreateResponse.rootValue.version)
+        val valueRequest = ValueUpdateRequest(propertyCreateResponse.rootValue.id, value, null, null, propertyCreateResponse.rootValue.version)
         val propertyFactsBefore = propertyEvents(factsBefore)
         val valueFactsBefore = valueEvents(factsBefore)
         val statesBefore = historyProvider.getAllHistory()
@@ -338,7 +337,7 @@ class ObjectHistoryTest {
     private fun prepareAnotherValue(prepared: PreparedValueInfo, value: ObjectValueData): PreparedValueInfo {
         val factsBefore: Set<HistoryFact> = historyService.getAll().toSet()
 
-        val valueRequest = ValueCreateRequest(value = value, description = null, objectPropertyId = prepared.propertyId)
+        val valueRequest = ValueCreateRequest(value, null, prepared.propertyId)
         val propertyFactsBefore = propertyEvents(factsBefore)
         val valueFactsBefore = valueEvents(factsBefore)
         val statesBefore = historyProvider.getAllHistory()
@@ -368,10 +367,7 @@ class ObjectHistoryTest {
     private fun prepareChildValue(prepared: PreparedValueInfo, aspectPropertyId: String?, value: ObjectValueData): PreparedValueInfo {
         val factsBefore: Set<HistoryFact> = historyService.getAll().toSet()
 
-        val valueRequest = ValueCreateRequest(
-            value = value, description = null, objectPropertyId = prepared.propertyId,
-            parentValueId = prepared.valueId, aspectPropertyId = aspectPropertyId, measureId = null
-        )
+        val valueRequest = ValueCreateRequest(value, null, prepared.propertyId, null, aspectPropertyId, prepared.valueId)
 
         val propertyFactsBefore = propertyEvents(factsBefore)
         val valueFactsBefore = valueEvents(factsBefore)
@@ -1683,8 +1679,7 @@ class ObjectHistoryTest {
         val objectDescription = "object description"
 
         val prepared = prepareValue(
-            objectName = testName, objectDescription = objectDescription, value = ObjectValueData.StringValue(value),
-            aspectId = aspect.idStrict(), measureId = measure.id
+            objectName = testName, objectDescription = objectDescription, value = ObjectValueData.StringValue(value), aspectId = aspect.idStrict()
         )
         val valueFacts = prepared.valueFacts
 

--- a/backend/src/test/kotlin/com/infowings/catalog/data/objekt/ObjectServiceExampleTest.kt
+++ b/backend/src/test/kotlin/com/infowings/catalog/data/objekt/ObjectServiceExampleTest.kt
@@ -4,22 +4,19 @@ import com.infowings.catalog.common.*
 import com.infowings.catalog.common.objekt.ObjectCreateRequest
 import com.infowings.catalog.common.objekt.PropertyCreateRequest
 import com.infowings.catalog.common.objekt.ValueCreateRequest
-import com.infowings.catalog.data.MeasureService
-import com.infowings.catalog.data.Subject
 import com.infowings.catalog.data.SubjectService
 import com.infowings.catalog.data.aspect.AspectService
 import com.infowings.catalog.data.reference.book.ReferenceBookService
 import com.infowings.catalog.storage.OrientDatabase
 import com.infowings.catalog.storage.id
 import com.infowings.catalog.storage.transaction
-import junit.framework.Assert.fail
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import kotlin.test.assertEquals
+import kotlin.test.fail
 
 
 @ExtendWith(SpringExtension::class)
@@ -32,66 +29,38 @@ class ObjectServiceExampleTest {
     @Autowired
     private lateinit var aspectService: AspectService
     @Autowired
-    private lateinit var measureService: MeasureService
-    @Autowired
     private lateinit var objectService: ObjectService
     @Autowired
     private lateinit var refBookService: ReferenceBookService
 
-    private lateinit var subject: Subject
-
-    private lateinit var aspect: AspectData
-
-    private lateinit var complexAspect: AspectData
-
     private val username = "admin"
-
-    @BeforeEach
-    fun initTestData() {
-        subject = subjectService.createSubject(SubjectData(name = "subjectName", description = "descr"), username)
-        aspect = aspectService.save(
-            AspectData(name = "aspectName", description = "aspectDescr", baseType = BaseType.Text.name), username
-        )
-        val property = AspectPropertyData("", "p", aspect.idStrict(), PropertyCardinality.INFINITY.name, null)
-        val complexAspectData = AspectData(
-            "",
-            "complex",
-            Kilometre.name,
-            null,
-            BaseType.Decimal.name,
-            listOf(property)
-        )
-        complexAspect = aspectService.save(complexAspectData, username)
-    }
 
     @Test
     fun createExampleTest() {
-        val aspectStage1 = aspectService.save(
-            AspectData(name = "current1", baseType = BaseType.Decimal.name), username
+        val aspectCurrent = aspectService.save(
+            AspectData(name = "Ток", baseType = BaseType.Decimal.name, measure = Ampere.name), username
         )
-        val aspectStage2 = aspectService.save(
-            AspectData(name = "current2", baseType = BaseType.Decimal.name), username
-        )
-        val aspectMaxTempr = aspectService.save(
+        val aspectTemperature = aspectService.save(
             AspectData(
-                name = "temperature",
+                name = "Температура",
                 description = "При нормальныхз условиях окружающей среды: T воздуха = 20 гр. C",
-                baseType = BaseType.Integer.name
+                measure = Celsius.name,
+                baseType = BaseType.Decimal.name
             ), username
         )
 
-        val propertyStage1 =
-            AspectPropertyData("", "1-й ступени ток", aspectStage1.idStrict(), PropertyCardinality.ONE.name, null)
-        val propertyStage2 =
-            AspectPropertyData("", "2-й ступени ток", aspectStage2.idStrict(), PropertyCardinality.ONE.name, null)
+        val propertyCurrentStage1 =
+            AspectPropertyData("", "1-й ступени", aspectCurrent.idStrict(), PropertyCardinality.ONE.name, null)
+        val propertyCurrentStage2 =
+            AspectPropertyData("", "2-й ступени", aspectCurrent.idStrict(), PropertyCardinality.ONE.name, null)
         val propertyMaxTempr =
-            AspectPropertyData("", "Max температура", aspectMaxTempr.idStrict(), PropertyCardinality.ONE.name, null)
+            AspectPropertyData("", "Max", aspectTemperature.idStrict(), PropertyCardinality.ONE.name, null)
 
         val aspectChargeMode = aspectService.save(
             AspectData(
-                name = "сharge",
+                name = "Режим заряда",
                 baseType = BaseType.Text.name,
-                properties = listOf(propertyStage1, propertyStage2, propertyMaxTempr)
+                properties = listOf(propertyCurrentStage1, propertyCurrentStage2, propertyMaxTempr)
             ), username
         )
 
@@ -100,20 +69,21 @@ class ObjectServiceExampleTest {
 
         fun chargeModeProperty(aspectId: String): String =
             chargeModePropertyByAspectId[aspectId]?.id
-                    ?: throw IllegalStateException("Not found property: $aspectStage1")
+                    ?: throw IllegalStateException("Not found property: $aspectId")
 
 
         val propertyChargeMode =
-            AspectPropertyData("", "Режим заряда", aspectChargeMode.idStrict(), PropertyCardinality.INFINITY.name, null)
+            AspectPropertyData("", null, aspectChargeMode.idStrict(), PropertyCardinality.INFINITY.name, null)
         val aspectChargeCharacteristic = aspectService.save(
             AspectData(
-                name = "сharge-characteristic",
+                name = "Характеристика заряда",
+                measure = null,
                 baseType = BaseType.Text.name,
                 properties = listOf(propertyChargeMode)
             ), username
         )
 
-        val refBook = refBookService.createReferenceBook("rb-charge", aspectChargeMode.idStrict(), username)
+        val refBook = refBookService.createReferenceBook("Режимы заряда", aspectChargeMode.idStrict(), username)
         val refBookItemIds = listOf("Ускоренный", "Номинальный", "Глубокий").map {
             val item = ReferenceBookItem(aspectChargeMode.idStrict(), it, "descr of $it", emptyList(), false, 0)
             refBookService.addReferenceBookItem(refBook.id, item, "admin")
@@ -144,8 +114,8 @@ class ObjectServiceExampleTest {
             value = ObjectValueData.Link(refValue11Data),
             description = null,
             objectPropertyId = propertyCreateResponse.id,
+            measureName = null,
             aspectPropertyId = aspectChargeCharacteristic.properties[0].id,
-            measureId = null,
             parentValueId = topValueId
         )
         val valueCreateResponse11 = objectService.create(value11Request, username)
@@ -155,8 +125,8 @@ class ObjectServiceExampleTest {
             value = ObjectValueData.Link(refValue12Data),
             description = null,
             objectPropertyId = propertyCreateResponse.id,
+            measureName = null,
             aspectPropertyId = aspectChargeCharacteristic.properties[0].id,
-            measureId = null,
             parentValueId = topValueId
         )
         val valueCreateResponse12 = objectService.create(value12Request, username)
@@ -166,8 +136,8 @@ class ObjectServiceExampleTest {
             value = ObjectValueData.Link(refValue13Data),
             description = null,
             objectPropertyId = propertyCreateResponse.id,
+            measureName = null,
             aspectPropertyId = aspectChargeCharacteristic.properties[0].id,
-            measureId = null,
             parentValueId = topValueId
         )
         val valueCreateResponse13 = objectService.create(value13Request, username)
@@ -176,31 +146,29 @@ class ObjectServiceExampleTest {
             value = ObjectValueData.DecimalValue("3.0"),
             description = null,
             objectPropertyId = propertyCreateResponse.id,
-            aspectPropertyId = chargeModeProperty(aspectStage1.idStrict()),
-            parentValueId = valueCreateResponse11.id,
-            measureId = null
+            measureName = Ampere.name,
+            aspectPropertyId = chargeModeProperty(aspectCurrent.idStrict()),
+            parentValueId = valueCreateResponse11.id
         )
         objectService.create(value111Request, username)
 
         val value112Request = ValueCreateRequest(
-            value = ObjectValueData.IntegerValue(75, null),
+            value = ObjectValueData.DecimalValue("75"),
             description = null,
             objectPropertyId = propertyCreateResponse.id,
-            aspectPropertyId = chargeModeProperty(aspectMaxTempr.idStrict()),
-            parentValueId = valueCreateResponse11.id,
-            measureId = null
+            measureName = Celsius.name,
+            aspectPropertyId = chargeModeProperty(aspectTemperature.idStrict()),
+            parentValueId = valueCreateResponse11.id
         )
         objectService.create(value112Request, username)
-
-        val ampereMeasure = measureService.findMeasure("Ampere")
 
         val value121Request = ValueCreateRequest(
             value = ObjectValueData.DecimalValue("0.8"),
             description = null,
             objectPropertyId = propertyCreateResponse.id,
-            aspectPropertyId = chargeModeProperty(aspectStage1.idStrict()),
-            parentValueId = valueCreateResponse12.id,
-            measureId = ampereMeasure?.id
+            measureName = Ampere.name,
+            aspectPropertyId = chargeModeProperty(aspectCurrent.idStrict()),
+            parentValueId = valueCreateResponse12.id
         )
         objectService.create(value121Request, username)
 
@@ -208,9 +176,9 @@ class ObjectServiceExampleTest {
             value = ObjectValueData.DecimalValue("1.2"),
             description = null,
             objectPropertyId = propertyCreateResponse.id,
-            aspectPropertyId = chargeModeProperty(aspectStage1.idStrict()),
-            parentValueId = valueCreateResponse13.id,
-            measureId = ampereMeasure?.id
+            measureName = Ampere.name,
+            aspectPropertyId = chargeModeProperty(aspectCurrent.idStrict()),
+            parentValueId = valueCreateResponse13.id
         )
         objectService.create(value131Request, username)
 
@@ -218,19 +186,19 @@ class ObjectServiceExampleTest {
             value = ObjectValueData.DecimalValue("0.3"),
             description = null,
             objectPropertyId = propertyCreateResponse.id,
-            aspectPropertyId = chargeModeProperty(aspectStage2.idStrict()),
-            parentValueId = valueCreateResponse13.id,
-            measureId = ampereMeasure?.id
+            measureName = Ampere.name,
+            aspectPropertyId = chargeModeProperty(aspectCurrent.idStrict()),
+            parentValueId = valueCreateResponse13.id
         )
         objectService.create(value132Request, username)
 
         val value133Request = ValueCreateRequest(
-            value = ObjectValueData.IntegerValue(45, null),
+            value = ObjectValueData.DecimalValue("45"),
             description = null,
             objectPropertyId = propertyCreateResponse.id,
-            aspectPropertyId = chargeModeProperty(aspectMaxTempr.idStrict()),
-            parentValueId = valueCreateResponse13.id,
-            measureId = null
+            measureName = Celsius.name,
+            aspectPropertyId = chargeModeProperty(aspectTemperature.idStrict()),
+            parentValueId = valueCreateResponse13.id
         )
         objectService.create(value133Request, username)
 

--- a/backend/src/test/kotlin/com/infowings/catalog/data/objekt/ObjectServiceExampleTest.kt
+++ b/backend/src/test/kotlin/com/infowings/catalog/data/objekt/ObjectServiceExampleTest.kt
@@ -18,7 +18,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 import kotlin.test.assertEquals
 import kotlin.test.fail
 
-
 @ExtendWith(SpringExtension::class)
 @SpringBootTest
 class ObjectServiceExampleTest {

--- a/backend/src/test/kotlin/com/infowings/catalog/data/objekt/ObjectServiceFetchTest.kt
+++ b/backend/src/test/kotlin/com/infowings/catalog/data/objekt/ObjectServiceFetchTest.kt
@@ -67,7 +67,7 @@ class ObjectServiceFetchTest {
                 ObjectValueData.DecimalValue("42"),
                 null,
                 boxDimensionPropertyCreateResponse.id,
-                null,
+                Metre.name,
                 dimensionsAspect.properties[0].id,
                 boxDimensionValueId
             ),
@@ -78,7 +78,7 @@ class ObjectServiceFetchTest {
                 ObjectValueData.DecimalValue("42"),
                 null,
                 boxDimensionPropertyCreateResponse.id,
-                null,
+                Metre.name,
                 dimensionsAspect.properties[1].id,
                 boxDimensionValueId
             ),
@@ -89,7 +89,7 @@ class ObjectServiceFetchTest {
                 ObjectValueData.DecimalValue("42"),
                 null,
                 boxDimensionPropertyCreateResponse.id,
-                null,
+                Metre.name,
                 dimensionsAspect.properties[2].id,
                 boxDimensionValueId
             ),

--- a/backend/src/test/kotlin/com/infowings/catalog/data/objekt/ObjectServiceTest.kt
+++ b/backend/src/test/kotlin/com/infowings/catalog/data/objekt/ObjectServiceTest.kt
@@ -132,7 +132,7 @@ class ObjectServiceTest {
             value = ObjectValueData.StringValue("Text Value"),
             description = null,
             objectPropertyId = propertyCreateResponse.id,
-            measureId = null,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
             parentValueId = defaultRootValueId
         )
@@ -179,6 +179,7 @@ class ObjectServiceTest {
         val valueRequest = ValueUpdateRequest(
             valueId = propertyCreateResponse.rootValue.id,
             value = ObjectValueData.StringValue(strValue),
+            measureName = null,
             description = null,
             version = propertyCreateResponse.rootValue.version
         )
@@ -360,7 +361,7 @@ class ObjectServiceTest {
         val propertyCreateResponse = objectService.create(propertyRequest, username)
 
         val valueRequest =
-            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue("123"), null, propertyCreateResponse.rootValue.version)
+            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue("123"), null, null, propertyCreateResponse.rootValue.version)
         val rootValueUpdateResponse = objectService.update(valueRequest, username)
 
         objectService.deleteObject(objectCreateResponse.id, username)
@@ -383,7 +384,7 @@ class ObjectServiceTest {
         val propertyCreateResponse = objectService.create(propertyRequest, username)
 
         val valueRequest =
-            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue("123"), null, propertyCreateResponse.rootValue.version)
+            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue("123"), null, null, propertyCreateResponse.rootValue.version)
         val rootValueUpdateResponse = objectService.update(valueRequest, username)
 
         objectService.softDeleteObject(objectCreateResponse.id, username)
@@ -408,6 +409,7 @@ class ObjectServiceTest {
         val valueRequest = ValueUpdateRequest(
             propertyCreateResponse.rootValue.id,
             ObjectValueData.Link(LinkValueData.Object(objectCreateResponse.id)),
+            null,
             null,
             propertyCreateResponse.rootValue.version
         )
@@ -435,6 +437,7 @@ class ObjectServiceTest {
         val valueRequest = ValueUpdateRequest(
             propertyCreateResponse.rootValue.id,
             ObjectValueData.Link(LinkValueData.Object(objectCreateResponse.id)),
+            null,
             null,
             propertyCreateResponse.version
         )
@@ -467,6 +470,7 @@ class ObjectServiceTest {
             propertyCreateResponse.rootValue.id,
             ObjectValueData.Link(LinkValueData.Object(objectCreateResponse1.id)),
             null,
+            null,
             propertyCreateResponse.rootValue.version
         )
         val valueUpdateResponse = objectService.update(valueRequest, username)
@@ -498,6 +502,7 @@ class ObjectServiceTest {
             propertyCreateResponse.rootValue.id,
             ObjectValueData.Link(LinkValueData.Object(objectCreateResponse.id)),
             null,
+            null,
             propertyCreateResponse.rootValue.version
         )
         val valueUpdateResponse = objectService.update(valueRequest, username)
@@ -520,7 +525,7 @@ class ObjectServiceTest {
         val propertyCreateResponse = objectService.create(propertyRequest, username)
 
         val valueRequest1 =
-            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue("123"), null, propertyCreateResponse.rootValue.version)
+            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue("123"), null, null, propertyCreateResponse.rootValue.version)
         val rootValueUpdateResponse = objectService.update(valueRequest1, username)
 
         val valueRequest2 = ValueCreateRequest(ObjectValueData.StringValue("234"), null, propertyCreateResponse.id)
@@ -546,7 +551,7 @@ class ObjectServiceTest {
         val propertyCreateResponse = objectService.create(propertyRequest, username)
 
         val valueRequest1 =
-            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue("123"), null, propertyCreateResponse.rootValue.version)
+            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue("123"), null, null, propertyCreateResponse.rootValue.version)
         val valueUpdateResponse = objectService.update(valueRequest1, username)
 
         val valueRequest2 = ValueCreateRequest(ObjectValueData.StringValue("234"), null, propertyCreateResponse.id)
@@ -573,12 +578,22 @@ class ObjectServiceTest {
         val propertyCreateResponse = objectService.create(propertyRequest, username)
 
         val valueRequest1 =
-            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.DecimalValue("123"), null, propertyCreateResponse.rootValue.version)
+            ValueUpdateRequest(
+                propertyCreateResponse.rootValue.id,
+                ObjectValueData.DecimalValue("123"),
+                Kilometre.name,
+                null,
+                propertyCreateResponse.rootValue.version
+            )
         val rootValueUpdateResponse = objectService.update(valueRequest1, username)
 
         val valueRequest2 = ValueCreateRequest(
-            value = ObjectValueData.StringValue("hello"), description = null, objectPropertyId = propertyCreateResponse.id,
-            measureId = null, aspectPropertyId = complexAspect.properties[0].id, parentValueId = rootValueUpdateResponse.id
+            ObjectValueData.StringValue("hello"),
+            null,
+            propertyCreateResponse.id,
+            null,
+            complexAspect.properties[0].id,
+            rootValueUpdateResponse.id
         )
         val childValueCreateResponse = objectService.create(valueRequest2, username)
 
@@ -603,12 +618,22 @@ class ObjectServiceTest {
         val propertyCreateResponse = objectService.create(propertyRequest, username)
 
         val valueRequest1 =
-            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.DecimalValue("123"), null, propertyCreateResponse.rootValue.version)
+            ValueUpdateRequest(
+                propertyCreateResponse.rootValue.id,
+                ObjectValueData.DecimalValue("123"),
+                Kilometre.name,
+                null,
+                propertyCreateResponse.rootValue.version
+            )
         val valueUpdateResponse = objectService.update(valueRequest1, username)
 
         val valueRequest2 = ValueCreateRequest(
-            value = ObjectValueData.StringValue("hello"), description = null, objectPropertyId = propertyCreateResponse.id,
-            measureId = null, aspectPropertyId = complexAspect.properties[0].id, parentValueId = valueUpdateResponse.id
+            ObjectValueData.StringValue("hello"),
+            null,
+            propertyCreateResponse.id,
+            null,
+            complexAspect.properties[0].id,
+            valueUpdateResponse.id
         )
         val childValueCreateResponse = objectService.create(valueRequest2, username)
 
@@ -700,7 +725,7 @@ class ObjectServiceTest {
         }
 
         val valueRequest1 =
-            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue("hello1"), null, propertyCreateResponse.rootValue.version)
+            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue("hello1"), null, null, propertyCreateResponse.rootValue.version)
         val valueUpdateResponse = objectService.update(valueRequest1, username)
 
         val valueRequest2 = ValueCreateRequest(ObjectValueData.StringValue("hello2"), null, propertyCreateResponse.id)
@@ -738,7 +763,7 @@ class ObjectServiceTest {
         }
 
         val valueRequest1 =
-            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue("hello1"), null, propertyCreateResponse.rootValue.version)
+            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue("hello1"), null, null, propertyCreateResponse.rootValue.version)
         val valueUpdateResponse = objectService.update(valueRequest1, username)
 
         val valueRequest2 = ValueCreateRequest(ObjectValueData.StringValue("hello2"), null, propertyCreateResponse.id)
@@ -776,16 +801,16 @@ class ObjectServiceTest {
         }
 
         val valueRequest1 =
-            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue("hello1"), null, propertyCreateResponse.rootValue.version)
+            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue("hello1"), null, null, propertyCreateResponse.rootValue.version)
         val valueUpdateResponse = objectService.update(valueRequest1, username)
 
         val valueRequest2 = ValueCreateRequest(
             value = ObjectValueData.StringValue("hello"),
             description = null,
             objectPropertyId = propertyCreateResponse.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            parentValueId = valueUpdateResponse.id,
-            measureId = null
+            parentValueId = valueUpdateResponse.id
         )
         val valueCreateResponse = objectService.create(valueRequest2, username)
 
@@ -820,16 +845,16 @@ class ObjectServiceTest {
         }
 
         val valueRequest1 =
-            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue("hello1"), null, propertyCreateResponse.rootValue.version)
+            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue("hello1"), null, null, propertyCreateResponse.rootValue.version)
         val valueUpdateResponse = objectService.update(valueRequest1, username)
 
         val valueRequest2 = ValueCreateRequest(
             value = ObjectValueData.StringValue("hello"),
             description = null,
             objectPropertyId = propertyCreateResponse.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            parentValueId = valueUpdateResponse.id,
-            measureId = null
+            parentValueId = valueUpdateResponse.id
         )
         val valueCreateResponse = objectService.create(valueRequest2, username)
 
@@ -867,6 +892,7 @@ class ObjectServiceTest {
         val valueRequest1 = ValueUpdateRequest(
             propertyCreateResponse.rootValue.id,
             ObjectValueData.Link(LinkValueData.ObjectProperty(propertyCreateResponse.id)),
+            null,
             null,
             propertyCreateResponse.rootValue.version
         )
@@ -906,6 +932,7 @@ class ObjectServiceTest {
         val valueRequest1 = ValueUpdateRequest(
             propertyCreateResponse.rootValue.id,
             ObjectValueData.Link(LinkValueData.ObjectProperty(propertyCreateResponse.id)),
+            null,
             null,
             propertyCreateResponse.rootValue.version
         )
@@ -951,6 +978,7 @@ class ObjectServiceTest {
         val valueRequest1 = ValueUpdateRequest(
             propertyCreateResponse1.rootValue.id,
             ObjectValueData.Link(LinkValueData.ObjectProperty(propertyCreateResponse2.id)),
+            null,
             null,
             propertyCreateResponse1.rootValue.version
         )
@@ -1000,6 +1028,7 @@ class ObjectServiceTest {
             propertyCreateResponse1.rootValue.id,
             ObjectValueData.Link(LinkValueData.ObjectProperty(propertyCreateResponse2.id)),
             null,
+            null,
             propertyCreateResponse1.rootValue.version
         )
         val valueUpdateResponse = objectService.update(valueRequest1, username)
@@ -1029,7 +1058,7 @@ class ObjectServiceTest {
         val propertyCreateResponse = objectService.create(propertyRequest, username)
 
         val valueRequest =
-            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue("hello"), null, propertyCreateResponse.rootValue.version)
+            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue("hello"), null, null, propertyCreateResponse.rootValue.version)
         val valueUpdateResponse = objectService.update(valueRequest, username)
 
         val createdProperty = objectService.findPropertyById(propertyCreateResponse.id)
@@ -1065,7 +1094,7 @@ class ObjectServiceTest {
         val propertyCreateResponse = objectService.create(propertyRequest, username)
 
         val valueRequest =
-            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue("hello"), null, propertyCreateResponse.rootValue.version)
+            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue("hello"), null, null, propertyCreateResponse.rootValue.version)
         val valueUpdateResponse = objectService.update(valueRequest, username)
 
         val createdProperty = objectService.findPropertyById(propertyCreateResponse.id)
@@ -1104,6 +1133,7 @@ class ObjectServiceTest {
             propertyCreateResponse.rootValue.id,
             ObjectValueData.StringValue("hello1"),
             null,
+            null,
             propertyCreateResponse.rootValue.version
         )
         val valueUpdateResponse = objectService.update(valueRequest, username)
@@ -1112,9 +1142,9 @@ class ObjectServiceTest {
             value = ObjectValueData.StringValue("hello2"),
             description = null,
             objectPropertyId = propertyCreateResponse.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            parentValueId = valueUpdateResponse.id,
-            measureId = null
+            parentValueId = valueUpdateResponse.id
         )
         val childValueCreateResponse = objectService.create(valueChildRequest, username)
 
@@ -1151,16 +1181,16 @@ class ObjectServiceTest {
         val propertyCreateResponse = objectService.create(propertyRequest, username)
 
         val valueRequest =
-            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue("hello1"), null, propertyCreateResponse.rootValue.version)
+            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue("hello1"), null, null, propertyCreateResponse.rootValue.version)
         val valueUpdateResponse = objectService.update(valueRequest, username)
 
         val valueChildRequest = ValueCreateRequest(
             value = ObjectValueData.StringValue("hello2"),
             description = null,
             objectPropertyId = propertyCreateResponse.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            parentValueId = valueUpdateResponse.id,
-            measureId = null
+            parentValueId = valueUpdateResponse.id
         )
         val childValueCreateResponse = objectService.create(valueChildRequest, username)
 
@@ -1197,16 +1227,16 @@ class ObjectServiceTest {
         val propertyCreateResponse = objectService.create(propertyRequest, username)
 
         val valueRequest =
-            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue("hello1"), null, propertyCreateResponse.rootValue.version)
+            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue("hello1"), null, null, propertyCreateResponse.rootValue.version)
         val valueUpdateResponse = objectService.update(valueRequest, username)
 
         val valueChildRequest = ValueCreateRequest(
             value = ObjectValueData.StringValue("hello2"),
             description = null,
             objectPropertyId = propertyCreateResponse.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            parentValueId = valueUpdateResponse.id,
-            measureId = null
+            parentValueId = valueUpdateResponse.id
         )
         val childValueCreateResponse = objectService.create(valueChildRequest, username)
 
@@ -1248,6 +1278,7 @@ class ObjectServiceTest {
             propertyCreateResponse.rootValue.id,
             ObjectValueData.StringValue("hello1"),
             null,
+            null,
             propertyCreateResponse.rootValue.version
         )
         val valueUpdateResponse = objectService.update(valueRequest, username)
@@ -1256,9 +1287,9 @@ class ObjectServiceTest {
             value = ObjectValueData.StringValue("hello2"),
             description = null,
             objectPropertyId = propertyCreateResponse.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            parentValueId = valueUpdateResponse.id,
-            measureId = null
+            parentValueId = valueUpdateResponse.id
         )
         val childValueCreateResponse = objectService.create(valueChildRequest, username)
 
@@ -1302,16 +1333,16 @@ class ObjectServiceTest {
         }
 
         val valueRequest1 =
-            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue(""), null, propertyCreateResponse.rootValue.version)
+            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue(""), null, null, propertyCreateResponse.rootValue.version)
         val valueUpdateResponse = objectService.update(valueRequest1, username)
 
         val valueRequest2 = ValueCreateRequest(
             value = ObjectValueData.Link(LinkValueData.ObjectValue(valueUpdateResponse.id)),
             description = null,
             objectPropertyId = propertyCreateResponse.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[1].id,
-            parentValueId = valueUpdateResponse.id,
-            measureId = null
+            parentValueId = valueUpdateResponse.id
         )
         val valueCreateResponse = objectService.create(valueRequest2, username)
 
@@ -1347,16 +1378,16 @@ class ObjectServiceTest {
         }
 
         val valueRequest1 =
-            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue(""), null, propertyCreateResponse.rootValue.version)
+            ValueUpdateRequest(propertyCreateResponse.rootValue.id, ObjectValueData.StringValue(""), null, null, propertyCreateResponse.rootValue.version)
         val valueUpdateResponse = objectService.update(valueRequest1, username)
 
         val valueRequest2 = ValueCreateRequest(
             value = ObjectValueData.Link(LinkValueData.ObjectValue(valueUpdateResponse.id)),
             description = null,
             objectPropertyId = propertyCreateResponse.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[1].id,
-            parentValueId = valueUpdateResponse.id,
-            measureId = null
+            parentValueId = valueUpdateResponse.id
         )
         val valueCreateResponse = objectService.create(valueRequest2, username)
 
@@ -1393,6 +1424,7 @@ class ObjectServiceTest {
             propertyCreateResponse1.rootValue.id,
             ObjectValueData.StringValue("1111"),
             null,
+            null,
             propertyCreateResponse1.rootValue.version
         )
         val valueUpdateResponse1 = objectService.update(valueRequest1, username)
@@ -1401,9 +1433,9 @@ class ObjectServiceTest {
             value = ObjectValueData.StringValue("222"),
             description = null,
             objectPropertyId = propertyCreateResponse1.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            parentValueId = valueUpdateResponse1.id,
-            measureId = null
+            parentValueId = valueUpdateResponse1.id
         )
         val valueCreateResponse = objectService.create(valueRequest2, username)
 
@@ -1417,6 +1449,7 @@ class ObjectServiceTest {
         val valueRequest3 = ValueUpdateRequest(
             propertyCreateResponse2.rootValue.id,
             ObjectValueData.Link(LinkValueData.ObjectValue(valueUpdateResponse1.id)),
+            null,
             null,
             propertyCreateResponse2.rootValue.version
         )
@@ -1456,16 +1489,16 @@ class ObjectServiceTest {
         }
 
         val valueRequest1 =
-            ValueUpdateRequest(propertyCreateResponse1.rootValue.id, ObjectValueData.StringValue("1111"), null, propertyCreateResponse1.rootValue.version)
+            ValueUpdateRequest(propertyCreateResponse1.rootValue.id, ObjectValueData.StringValue("1111"), null, null, propertyCreateResponse1.rootValue.version)
         val valueUpdateResponse1 = objectService.update(valueRequest1, username)
 
         val valueRequest2 = ValueCreateRequest(
             value = ObjectValueData.StringValue("222"),
             description = null,
             objectPropertyId = propertyCreateResponse1.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            parentValueId = valueUpdateResponse1.id,
-            measureId = null
+            parentValueId = valueUpdateResponse1.id
         )
         val valueCreateResponse = objectService.create(valueRequest2, username)
 
@@ -1479,6 +1512,7 @@ class ObjectServiceTest {
         val valueRequest3 = ValueUpdateRequest(
             propertyCreateResponse2.rootValue.id,
             ObjectValueData.Link(LinkValueData.ObjectValue(valueUpdateResponse1.id)),
+            null,
             null,
             propertyCreateResponse2.rootValue.version
         )
@@ -1515,16 +1549,16 @@ class ObjectServiceTest {
         }
 
         val valueRequest1 =
-            ValueUpdateRequest(propertyCreateResponse1.rootValue.id, ObjectValueData.StringValue("1111"), null, propertyCreateResponse1.rootValue.version)
+            ValueUpdateRequest(propertyCreateResponse1.rootValue.id, ObjectValueData.StringValue("1111"), null, null, propertyCreateResponse1.rootValue.version)
         val valueUpdateResponse1 = objectService.update(valueRequest1, username)
 
         val valueRequest2 = ValueCreateRequest(
             value = ObjectValueData.StringValue("222"),
             description = null,
             objectPropertyId = propertyCreateResponse1.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            parentValueId = valueUpdateResponse1.id,
-            measureId = null
+            parentValueId = valueUpdateResponse1.id
         )
         val valueCreateResponse = objectService.create(valueRequest2, username)
 
@@ -1538,6 +1572,7 @@ class ObjectServiceTest {
         val valueRequest3 = ValueUpdateRequest(
             propertyCreateResponse2.rootValue.id,
             ObjectValueData.Link(LinkValueData.ObjectValue(valueCreateResponse.id)),
+            null,
             null,
             propertyCreateResponse2.rootValue.version
         )
@@ -1578,16 +1613,16 @@ class ObjectServiceTest {
         }
 
         val valueRequest1 =
-            ValueUpdateRequest(propertyCreateResponse1.rootValue.id, ObjectValueData.StringValue("1111"), null, propertyCreateResponse1.rootValue.version)
+            ValueUpdateRequest(propertyCreateResponse1.rootValue.id, ObjectValueData.StringValue("1111"), null, null, propertyCreateResponse1.rootValue.version)
         val valueUpdateResponse1 = objectService.update(valueRequest1, username)
 
         val valueRequest2 = ValueCreateRequest(
             value = ObjectValueData.StringValue("222"),
             description = null,
             objectPropertyId = propertyCreateResponse1.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            parentValueId = valueUpdateResponse1.id,
-            measureId = null
+            parentValueId = valueUpdateResponse1.id
         )
         val valueCreateResponse = objectService.create(valueRequest2, username)
 
@@ -1601,6 +1636,7 @@ class ObjectServiceTest {
         val valueRequest3 = ValueUpdateRequest(
             propertyCreateResponse2.rootValue.id,
             ObjectValueData.Link(LinkValueData.ObjectValue(valueCreateResponse.id)),
+            null,
             null,
             propertyCreateResponse2.rootValue.version
         )
@@ -1637,16 +1673,16 @@ class ObjectServiceTest {
         }
 
         val valueRequest1 =
-            ValueUpdateRequest(propertyCreateResponse1.rootValue.id, ObjectValueData.StringValue("1111"), null, propertyCreateResponse1.rootValue.version)
+            ValueUpdateRequest(propertyCreateResponse1.rootValue.id, ObjectValueData.StringValue("1111"), null, null, propertyCreateResponse1.rootValue.version)
         val valueUpdateResponse1 = objectService.update(valueRequest1, username)
 
         val valueRequest2 = ValueCreateRequest(
             value = ObjectValueData.StringValue("222"),
             description = null,
             objectPropertyId = propertyCreateResponse1.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            parentValueId = valueUpdateResponse1.id,
-            measureId = null
+            parentValueId = valueUpdateResponse1.id
         )
         val valueCreateResponse = objectService.create(valueRequest2, username)
 
@@ -1660,6 +1696,7 @@ class ObjectServiceTest {
         val valueRequest3 = ValueUpdateRequest(
             propertyCreateResponse2.rootValue.id,
             ObjectValueData.Link(LinkValueData.ObjectValue(valueUpdateResponse1.id)),
+            null,
             null,
             propertyCreateResponse2.rootValue.version
         )
@@ -1698,16 +1735,16 @@ class ObjectServiceTest {
         }
 
         val valueRequest1 =
-            ValueUpdateRequest(propertyCreateResponse1.rootValue.id, ObjectValueData.StringValue("1111"), null, propertyCreateResponse1.rootValue.version)
+            ValueUpdateRequest(propertyCreateResponse1.rootValue.id, ObjectValueData.StringValue("1111"), null, null, propertyCreateResponse1.rootValue.version)
         val valueUpdateResponse1 = objectService.update(valueRequest1, username)
 
         val valueRequest2 = ValueCreateRequest(
             value = ObjectValueData.StringValue("222"),
             description = null,
             objectPropertyId = propertyCreateResponse1.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            parentValueId = valueUpdateResponse1.id,
-            measureId = null
+            parentValueId = valueUpdateResponse1.id
         )
         val valueCreateResponse = objectService.create(valueRequest2, username)
 
@@ -1721,6 +1758,7 @@ class ObjectServiceTest {
         val valueRequest3 = ValueUpdateRequest(
             propertyCreateResponse2.rootValue.id,
             ObjectValueData.Link(LinkValueData.ObjectValue(valueUpdateResponse1.id)),
+            null,
             null,
             propertyCreateResponse2.rootValue.version
         )
@@ -1756,16 +1794,16 @@ class ObjectServiceTest {
         }
 
         val valueRequest1 =
-            ValueUpdateRequest(propertyCreateResponse1.rootValue.id, ObjectValueData.StringValue("1111"), null, propertyCreateResponse1.rootValue.version)
+            ValueUpdateRequest(propertyCreateResponse1.rootValue.id, ObjectValueData.StringValue("1111"), null, null, propertyCreateResponse1.rootValue.version)
         val valueUpdateResponse1 = objectService.update(valueRequest1, username)
 
         val valueRequest2 = ValueCreateRequest(
             value = ObjectValueData.StringValue("222"),
             description = null,
             objectPropertyId = propertyCreateResponse1.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            parentValueId = valueUpdateResponse1.id,
-            measureId = null
+            parentValueId = valueUpdateResponse1.id
         )
         val valueCreateResponse = objectService.create(valueRequest2, username)
 
@@ -1779,6 +1817,7 @@ class ObjectServiceTest {
         val valueRequest3 = ValueUpdateRequest(
             propertyCreateResponse2.rootValue.id,
             ObjectValueData.Link(LinkValueData.ObjectValue(valueCreateResponse.id)),
+            null,
             null,
             propertyCreateResponse2.rootValue.version
         )
@@ -1818,16 +1857,16 @@ class ObjectServiceTest {
         }
 
         val valueRequest1 =
-            ValueUpdateRequest(propertyCreateResponse1.rootValue.id, ObjectValueData.StringValue("1111"), null, propertyCreateResponse1.rootValue.version)
+            ValueUpdateRequest(propertyCreateResponse1.rootValue.id, ObjectValueData.StringValue("1111"), null, null, propertyCreateResponse1.rootValue.version)
         val valueUpdateResponse1 = objectService.update(valueRequest1, username)
 
         val valueRequest2 = ValueCreateRequest(
             value = ObjectValueData.StringValue("222"),
             description = null,
             objectPropertyId = propertyCreateResponse1.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            parentValueId = valueUpdateResponse1.id,
-            measureId = null
+            parentValueId = valueUpdateResponse1.id
         )
         val valueCreateResponse = objectService.create(valueRequest2, username)
 
@@ -1841,6 +1880,7 @@ class ObjectServiceTest {
         val valueRequest3 = ValueUpdateRequest(
             propertyCreateResponse2.rootValue.id,
             ObjectValueData.Link(LinkValueData.ObjectValue(valueCreateResponse.id)),
+            null,
             null,
             propertyCreateResponse2.rootValue.version
         )
@@ -1882,16 +1922,16 @@ class ObjectServiceTest {
         }
 
         val valueRequest1 =
-            ValueUpdateRequest(propertyCreateResponse1.rootValue.id, ObjectValueData.StringValue("1111"), null, propertyCreateResponse1.rootValue.version)
+            ValueUpdateRequest(propertyCreateResponse1.rootValue.id, ObjectValueData.StringValue("1111"), null, null, propertyCreateResponse1.rootValue.version)
         val valueUpdateResponse1 = objectService.update(valueRequest1, username)
 
         val valueRequest2 = ValueCreateRequest(
             value = ObjectValueData.StringValue("222"),
             description = null,
             objectPropertyId = propertyCreateResponse1.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            parentValueId = valueUpdateResponse1.id,
-            measureId = null
+            parentValueId = valueUpdateResponse1.id
         )
         val valueCreateResponse = objectService.create(valueRequest2, username)
 
@@ -1905,6 +1945,7 @@ class ObjectServiceTest {
         val valueRequest3 = ValueUpdateRequest(
             propertyCreateResponse2.rootValue.id,
             ObjectValueData.Link(LinkValueData.ObjectValue(valueUpdateResponse1.id)),
+            null,
             null,
             propertyCreateResponse2.rootValue.version
         )
@@ -1950,16 +1991,16 @@ class ObjectServiceTest {
         }
 
         val valueRequest1 =
-            ValueUpdateRequest(propertyCreateResponse1.rootValue.id, ObjectValueData.StringValue("1111"), null, propertyCreateResponse1.rootValue.version)
+            ValueUpdateRequest(propertyCreateResponse1.rootValue.id, ObjectValueData.StringValue("1111"), null, null, propertyCreateResponse1.rootValue.version)
         val valueUpdateResponse1 = objectService.update(valueRequest1, username)
 
         val valueRequest2 = ValueCreateRequest(
             value = ObjectValueData.StringValue("222"),
             description = null,
             objectPropertyId = propertyCreateResponse1.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            parentValueId = valueUpdateResponse1.id,
-            measureId = null
+            parentValueId = valueUpdateResponse1.id
         )
         val valueCreateResponse = objectService.create(valueRequest2, username)
 
@@ -1973,6 +2014,7 @@ class ObjectServiceTest {
         val valueRequest3 = ValueUpdateRequest(
             propertyCreateResponse2.rootValue.id,
             ObjectValueData.Link(LinkValueData.ObjectValue(valueUpdateResponse1.id)),
+            null,
             null,
             propertyCreateResponse2.rootValue.version
         )
@@ -2012,16 +2054,16 @@ class ObjectServiceTest {
         }
 
         val valueRequest1 =
-            ValueUpdateRequest(propertyCreateResponse1.rootValue.id, ObjectValueData.StringValue("1111"), null, propertyCreateResponse1.rootValue.version)
+            ValueUpdateRequest(propertyCreateResponse1.rootValue.id, ObjectValueData.StringValue("1111"), null, null, propertyCreateResponse1.rootValue.version)
         val valueUpdateResponse1 = objectService.update(valueRequest1, username)
 
         val valueRequest2 = ValueCreateRequest(
             value = ObjectValueData.StringValue("222"),
             description = null,
             objectPropertyId = propertyCreateResponse1.id,
+            measureName = null,
             aspectPropertyId = complexAspect.properties[0].id,
-            parentValueId = valueUpdateResponse1.id,
-            measureId = null
+            parentValueId = valueUpdateResponse1.id
         )
         val valueCreateResponse = objectService.create(valueRequest2, username)
 
@@ -2035,6 +2077,7 @@ class ObjectServiceTest {
         val valueRequest3 = ValueUpdateRequest(
             propertyCreateResponse2.rootValue.id,
             ObjectValueData.Link(LinkValueData.ObjectValue(valueCreateResponse.id)),
+            null,
             null,
             propertyCreateResponse2.rootValue.version
         )

--- a/backend/src/test/kotlin/com/infowings/catalog/data/objekt/ObjectValidatorTest.kt
+++ b/backend/src/test/kotlin/com/infowings/catalog/data/objekt/ObjectValidatorTest.kt
@@ -16,7 +16,6 @@ import com.infowings.catalog.randomName
 import com.infowings.catalog.storage.*
 import com.orientechnologies.orient.core.id.ORecordId
 import com.orientechnologies.orient.core.record.impl.OVertexDocument
-import junit.framework.Assert.fail
 import org.junit.Assert
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -25,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import kotlin.test.assertEquals
+import kotlin.test.fail
 
 
 @ExtendWith(SpringExtension::class)
@@ -234,11 +234,15 @@ class ObjectValidatorTest {
         val savedProperty = createObjectProperty(propertyRequest)
         val scalarValue = ObjectValueData.IntegerValue(123, null)
         val valueRequest = ValueCreateRequest(value = scalarValue, description = null, objectPropertyId = savedProperty.id)
-        val objectValue = validator.checkedForCreation(valueRequest)
 
-        assertEquals(scalarValue, objectValue.value.toObjectValueData(), "values must be equal")
-        assertEquals(valueRequest.aspectPropertyId, objectValue.aspectProperty?.id, "root characteristics must be equal")
-        assertEquals(valueRequest.objectPropertyId, objectValue.objectProperty.id, "root characteristics must be equal")
+        transaction(db) {
+            val objectValue = validator.checkedForCreation(valueRequest)
+
+            assertEquals(scalarValue, objectValue.value.toObjectValueData(), "values must be equal")
+            assertEquals(valueRequest.aspectPropertyId, objectValue.aspectProperty?.id, "root characteristics must be equal")
+            assertEquals(valueRequest.objectPropertyId, objectValue.objectProperty.id, "root characteristics must be equal")
+        }
+
     }
 
     @Test
@@ -257,11 +261,14 @@ class ObjectValidatorTest {
         val createdProperty = createObjectProperty(propertyRequest)
 
         val scalarValue = ObjectValueData.IntegerValue(123, null)
-        val valueData = ValueCreateRequest.root(scalarValue, null, createdProperty.id)
-        val objectValue = validator.checkedForCreation(valueData)
+        val valueData = ValueCreateRequest(scalarValue, null, createdProperty.id)
 
-        assertEquals(scalarValue, objectValue.value.toObjectValueData(), "scalar values must be equal")
-        assertEquals(valueData.objectPropertyId, objectValue.objectProperty.id, "object properties must be equal")
+        transaction(db) {
+            val objectValue = validator.checkedForCreation(valueData)
+
+            assertEquals(scalarValue, objectValue.value.toObjectValueData(), "scalar values must be equal")
+            assertEquals(valueData.objectPropertyId, objectValue.objectProperty.id, "object properties must be equal")
+        }
     }
 
 
@@ -279,11 +286,14 @@ class ObjectValidatorTest {
 
         val scalarValue = ObjectValueData.StringValue("string-value")
         val valueRequest = ValueCreateRequest(value = scalarValue, description = null, objectPropertyId = createdProperty.id)
-        val valueInfo = validator.checkedForCreation(valueRequest)
 
-        assertEquals(scalarValue, valueInfo.value.toObjectValueData(), "values must be equal")
-        assertEquals(valueRequest.aspectPropertyId, valueInfo.aspectProperty?.id, "aspect properties must be equal")
-        assertEquals(valueRequest.objectPropertyId, valueInfo.objectProperty.id, "object properties must be equal")
+        transaction(db) {
+            val valueInfo = validator.checkedForCreation(valueRequest)
+
+            assertEquals(scalarValue, valueInfo.value.toObjectValueData(), "values must be equal")
+            assertEquals(valueRequest.aspectPropertyId, valueInfo.aspectProperty?.id, "aspect properties must be equal")
+            assertEquals(valueRequest.objectPropertyId, valueInfo.objectProperty.id, "object properties must be equal")
+        }
     }
 
     @Test
@@ -303,11 +313,13 @@ class ObjectValidatorTest {
             description = null, objectId = objectVertex.id, aspectId = complexAspect.idStrict()
         )
 
-        val propertyInfo = validator.checkedForCreation(propertyRequest2)
+        transaction(db) {
+            val propertyInfo = validator.checkedForCreation(propertyRequest2)
 
-        assertEquals(propertyRequest2.name, propertyInfo.name, "names must be equal")
-        assertEquals(propertyRequest2.objectId, propertyInfo.objekt.id, "object id must keep the same")
-        assertEquals(propertyRequest2.aspectId, propertyInfo.aspect.id, "aspect id must keep the same")
+            assertEquals(propertyRequest2.name, propertyInfo.name, "names must be equal")
+            assertEquals(propertyRequest2.objectId, propertyInfo.objekt.id, "object id must keep the same")
+            assertEquals(propertyRequest2.aspectId, propertyInfo.aspect.id, "aspect id must keep the same")
+        }
     }
 
 

--- a/backend/src/test/kotlin/com/infowings/catalog/data/objekt/ObjectValidatorTest.kt
+++ b/backend/src/test/kotlin/com/infowings/catalog/data/objekt/ObjectValidatorTest.kt
@@ -26,7 +26,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 import kotlin.test.assertEquals
 import kotlin.test.fail
 
-
 @ExtendWith(SpringExtension::class)
 @SpringBootTest
 @Suppress("StringLiteralDuplication")

--- a/backend/src/test/kotlin/com/infowings/catalog/data/reference/book/ReferenceBookLinkedTest.kt
+++ b/backend/src/test/kotlin/com/infowings/catalog/data/reference/book/ReferenceBookLinkedTest.kt
@@ -159,6 +159,7 @@ class ReferenceBookLinkedTest {
         val objPropertyRootValueRequest = ValueUpdateRequest(
             propertyCreateResponse.rootValue.id,
             ObjectValueData.DecimalValue("123.1"),
+            Kilometre.name,
             null,
             propertyCreateResponse.rootValue.version
         )
@@ -167,8 +168,8 @@ class ReferenceBookLinkedTest {
             value = ObjectValueData.Link(LinkValueData.DomainElement(idForLinking)),
             description = null,
             objectPropertyId = propertyCreateResponse.id,
+            measureName = null,
             aspectPropertyId = aspectWithObjectProperty.properties[0].id,
-            measureId = null,
             parentValueId = rootValueUpdateResponse.id
         )
         objectService.create(objPropertyValueRequest, username)

--- a/common/src/main/kotlin/com/infowings/catalog/common/Measure.kt
+++ b/common/src/main/kotlin/com/infowings/catalog/common/Measure.kt
@@ -1,3 +1,4 @@
+@file:Suppress("StringLiteralDuplication")
 package com.infowings.catalog.common
 
 val MeasureDesc: Map<String, String> = mapOf(
@@ -115,6 +116,7 @@ val MeasureGroupDesc: Map<String, String> = mapOf(
     "Euro Money Group" to ""
 )
 
+@Suppress("UnusedPrivateMember")
 expect class DecimalNumber(value: String) {
     constructor(value: Int)
     constructor(value: Double)

--- a/common/src/main/kotlin/com/infowings/catalog/common/Measure.kt
+++ b/common/src/main/kotlin/com/infowings/catalog/common/Measure.kt
@@ -115,8 +115,9 @@ val MeasureGroupDesc: Map<String, String> = mapOf(
     "Euro Money Group" to ""
 )
 
-expect class DecimalNumber(value: Double) {
+expect class DecimalNumber(value: String) {
     constructor(value: Int)
+    constructor(value: Double)
 
     operator fun minus(other: DecimalNumber): DecimalNumber
     operator fun times(other: DecimalNumber): DecimalNumber
@@ -145,7 +146,7 @@ expect sealed class BaseType(_name: String) {
 fun createDecimalMeasure(
     name: String,
     symbol: String,
-    coefficient: Double
+    coefficient: String
 ): Measure<DecimalNumber> =
     Measure(
         name,
@@ -178,17 +179,17 @@ class MeasureGroup<T>(
 
 
 /** Length group */
-val Kilometre = createDecimalMeasure("Kilometer", "km", 1000.0)
-val Metre = createDecimalMeasure("Metre", "m", 1.0)
-val Decimeter = createDecimalMeasure("Decimeter", "dm", 0.1)
-val Centimeter = createDecimalMeasure("Centimeter", "cm", 0.01)
-val Millimetre = createDecimalMeasure("Millimeter", "mm", 0.001)
-val Micrometer = createDecimalMeasure("Micrometer", "micrometre", 0.000001)
-val Nanometer = createDecimalMeasure("Nanometer", "nm", 0.000000001)
-val Yard = createDecimalMeasure("Yard", "yard", 0.9144)
-val Inch = createDecimalMeasure("Inch", "inch", 0.0253999368683)
-val Mile = createDecimalMeasure("Mile", "mile", 1609.344)
-val Foot = createDecimalMeasure("Foot", "ft", 0.3048)
+val Kilometre = createDecimalMeasure("Kilometer", "km", "1000.0")
+val Metre = createDecimalMeasure("Metre", "m", "1.0")
+val Decimeter = createDecimalMeasure("Decimeter", "dm", "0.1")
+val Centimeter = createDecimalMeasure("Centimeter", "cm", "0.01")
+val Millimetre = createDecimalMeasure("Millimeter", "mm", "0.001")
+val Micrometer = createDecimalMeasure("Micrometer", "micrometre", "0.000001")
+val Nanometer = createDecimalMeasure("Nanometer", "nm", "0.000000001")
+val Yard = createDecimalMeasure("Yard", "yard", "0.9144")
+val Inch = createDecimalMeasure("Inch", "inch", "0.0253999368683")
+val Mile = createDecimalMeasure("Mile", "mile", "1609.344")
+val Foot = createDecimalMeasure("Foot", "ft", "0.3048")
 
 val LengthGroup = MeasureGroup(
     "Length",
@@ -197,12 +198,12 @@ val LengthGroup = MeasureGroup(
 )
 
 /** Speed group */
-val KilometerPerSecond = createDecimalMeasure("Kilometer per Second", "km/s", 1000.0)
-val MilePerHour = createDecimalMeasure("Mile per Hour", "mile/s", 0.44704)
-val InchPerSecond = createDecimalMeasure("Inch per Second", "inch/s", 0.3048)
-val MetrePerSecond = createDecimalMeasure("Metre per Second", "m/s", 1.0)
-val KilometerPerHour = createDecimalMeasure("Kilometer per Hour", "km/h", 0.277778)
-val Knot = createDecimalMeasure("Knot", "knot", 0.514444)
+val KilometerPerSecond = createDecimalMeasure("Kilometer per Second", "km/s", "1000.0")
+val MilePerHour = createDecimalMeasure("Mile per Hour", "mile/s", "0.44704")
+val InchPerSecond = createDecimalMeasure("Inch per Second", "inch/s", "0.3048")
+val MetrePerSecond = createDecimalMeasure("Metre per Second", "m/s", "1.0")
+val KilometerPerHour = createDecimalMeasure("Kilometer per Hour", "km/h", "0.277778")
+val Knot = createDecimalMeasure("Knot", "knot", "0.514444")
 
 val SpeedGroup = MeasureGroup(
     "Speed",
@@ -211,21 +212,21 @@ val SpeedGroup = MeasureGroup(
 )
 
 /** Area group */
-val SquareMetre = createDecimalMeasure("Square meter", "m^2", 1.0)
-val Hectare = createDecimalMeasure("Hectare", "ha", 10000.0)
-val SquareInch = createDecimalMeasure("Square Inch", "inch^2", 0.00064516)
+val SquareMetre = createDecimalMeasure("Square meter", "m^2", "1.0")
+val Hectare = createDecimalMeasure("Hectare", "ha", "10000.0")
+val SquareInch = createDecimalMeasure("Square Inch", "inch^2", "0.00064516")
 
 val AreaGroup = MeasureGroup("Area", listOf(SquareMetre, Hectare, SquareInch), SquareMetre)
 
 /** Volume group */
-val CubicMetre = createDecimalMeasure("Cubic Metre", "m^3", 1.0)
-val CubicMillimetre = createDecimalMeasure("Cubic Millimetre", "millimetre^3", 1E-9)
-val Litre = createDecimalMeasure("Litre", "litre", 0.001)
-val CubicDecimetre = createDecimalMeasure("Cubic Decimeter", "dm^3", 0.001)
-val CubicCentimetre = createDecimalMeasure("Cubic Centimeter", "cm^3", 0.000001)
-val CubicInch = createDecimalMeasure("Cubic Inch", "inch^2", 1.6387e-5)
-val Pint = createDecimalMeasure("Pint", "pint", 0.0004731765)
-val Gallon = createDecimalMeasure("Gallon", "gallon", 0.00378541178)
+val CubicMetre = createDecimalMeasure("Cubic Metre", "m^3", "1.0")
+val CubicMillimetre = createDecimalMeasure("Cubic Millimetre", "millimetre^3", "0.000000001")
+val Litre = createDecimalMeasure("Litre", "litre", "0.001")
+val CubicDecimetre = createDecimalMeasure("Cubic Decimeter", "dm^3", "0.001")
+val CubicCentimetre = createDecimalMeasure("Cubic Centimeter", "cm^3", "0.000001")
+val CubicInch = createDecimalMeasure("Cubic Inch", "inch^2", "0.000016387")
+val Pint = createDecimalMeasure("Pint", "pint", "0.0004731765")
+val Gallon = createDecimalMeasure("Gallon", "gallon", "0.00378541178")
 
 val VolumeGroup = MeasureGroup(
     "Volume",
@@ -234,62 +235,62 @@ val VolumeGroup = MeasureGroup(
 )
 
 /** Mass group */
-val Gram = createDecimalMeasure("Gram", "g", 0.001)
-val Milligram = createDecimalMeasure("Milligram", "mg", 1e-6)
-val Kilogram = createDecimalMeasure("Kilogram", "kg", 1.0)
-val Tonne = createDecimalMeasure("Tonne", "tn", 1000.0)
-val PoundMass = createDecimalMeasure("Pound(mass)", "lb", 0.4535923)
+val Gram = createDecimalMeasure("Gram", "g", "0.001")
+val Milligram = createDecimalMeasure("Milligram", "mg", "0.000001")
+val Kilogram = createDecimalMeasure("Kilogram", "kg", "1.0")
+val Tonne = createDecimalMeasure("Tonne", "tn", "1000.0")
+val PoundMass = createDecimalMeasure("Pound(mass)", "lb", "0.4535923")
 
 val MassGroup = MeasureGroup("Mass", listOf(Gram, Milligram, Kilogram, Tonne, PoundMass), Kilogram)
 
 /** Power group */
-val Watt = createDecimalMeasure("Watt", "W", 1.0)
-val Kilowatt = createDecimalMeasure("Kilowatt", "kW", 1000.0)
-val Horsepower = createDecimalMeasure("Horsepower", "hp", 745.699872)
-val VoltAmpere = createDecimalMeasure("Volt-ampere", "VA", 1.0)
+val Watt = createDecimalMeasure("Watt", "W", "1.0")
+val Kilowatt = createDecimalMeasure("Kilowatt", "kW", "1000.0")
+val Horsepower = createDecimalMeasure("Horsepower", "hp", "745.699872")
+val VoltAmpere = createDecimalMeasure("Volt-ampere", "VA", "1.0")
 
 val PowerGroup = MeasureGroup("Power", listOf(Watt, Kilowatt, Horsepower, VoltAmpere), Watt)
 
 /** Voltage group */
-val Volt = createDecimalMeasure("Volt", "V", 1.0)
-val Millivolt = createDecimalMeasure("Millivolt", "mV", 0.001)
-val Kilovolt = createDecimalMeasure("Kilovolt", "kV", 1000.0)
+val Volt = createDecimalMeasure("Volt", "V", "1.0")
+val Millivolt = createDecimalMeasure("Millivolt", "mV", "0.001")
+val Kilovolt = createDecimalMeasure("Kilovolt", "kV", "1000.0")
 
 val VoltageGroup = MeasureGroup("Voltage", listOf(Volt, Millivolt, Kilovolt), Volt)
 
 /** ReactivePower group */
-val Var = createDecimalMeasure("Var", "var", 1.0)
-val Kilovar = createDecimalMeasure("Kilovar", "kilovar", 1000.0)
+val Var = createDecimalMeasure("Var", "var", "1.0")
+val Kilovar = createDecimalMeasure("Kilovar", "kilovar", "1000.0")
 
 val ReactivePowerGroup = MeasureGroup("Reactive Power", listOf(Var, Kilovar), Var)
 
 /** WorkEnergy group */
-val Joule = createDecimalMeasure("Joule", "J", 1.0)
-val Kilojoule = createDecimalMeasure("Kilojoule", "kJ", 1000.0)
-val WattHour = createDecimalMeasure("Watt-Hour", "wh", 3600.0)
-val KilowattHour = createDecimalMeasure("Kilowatt-Hour", "kwh", 3_600_000.0)
+val Joule = createDecimalMeasure("Joule", "J", "1.0")
+val Kilojoule = createDecimalMeasure("Kilojoule", "kJ", "1000.0")
+val WattHour = createDecimalMeasure("Watt-Hour", "wh", "3600.0")
+val KilowattHour = createDecimalMeasure("Kilowatt-Hour", "kwh", "3600000")
 
 val WorkEnergyGroup = MeasureGroup("Work and Energy", listOf(Joule, Kilojoule, WattHour, KilowattHour), Joule)
 
 /** ElectricCurrent group */
-val Ampere = createDecimalMeasure("Ampere", "A", 1.0)
-val MilliAmpere = createDecimalMeasure("Milliampere", "mA", 0.001)
+val Ampere = createDecimalMeasure("Ampere", "A", "1.0")
+val MilliAmpere = createDecimalMeasure("Milliampere", "mA", "0.001")
 
 val ElectricCurrentGroup = MeasureGroup("Electric Current", listOf(Ampere, MilliAmpere), Ampere)
 
 /** ElectricCharge group */
-val Coulomb = createDecimalMeasure("Coulomb", "C", 1.0)
-val AmpereHour = createDecimalMeasure("Ampere-Hour", "Ah", 3600.0)
+val Coulomb = createDecimalMeasure("Coulomb", "C", "1.0")
+val AmpereHour = createDecimalMeasure("Ampere-Hour", "Ah", "3600.0")
 val ElectricChargeGroup = MeasureGroup("Electric charge", listOf(Coulomb, AmpereHour), Coulomb)
 
 /** ElectricalResistance group */
-val Om = createDecimalMeasure("Om", "Om", 1.0)
-val MilliOm = createDecimalMeasure("Milliom", "mOm", 0.001)
+val Om = createDecimalMeasure("Om", "Om", "1.0")
+val MilliOm = createDecimalMeasure("Milliom", "mOm", "0.001")
 
 val ElectricalResistanceGroup = MeasureGroup("Electrical Resistance", listOf(Om, MilliOm), Om)
 
 /** Temperature group */
-val Celsius = createDecimalMeasure("Celsius", "C", 1.0)
+val Celsius = createDecimalMeasure("Celsius", "C", "1.0")
 val Fahrenheit = Measure<DecimalNumber>(
     "Fahrenheit",
     "F",
@@ -301,18 +302,18 @@ val Fahrenheit = Measure<DecimalNumber>(
 val TemperatureGroup = MeasureGroup("Temperature", listOf(Celsius, Fahrenheit), Celsius)
 
 /** Force group */
-val Newton = createDecimalMeasure("Newton", "N", 1.0)
+val Newton = createDecimalMeasure("Newton", "N", "1.0")
 val ForceGroup = MeasureGroup("Force", listOf(Newton), Newton)
 
 /** Frequency group */
-val Hertz = createDecimalMeasure("Hertz", "Hz", 1.0)
-val Kilohertz = createDecimalMeasure("Kilohertz", "kHz", 1000.0)
+val Hertz = createDecimalMeasure("Hertz", "Hz", "1.0")
+val Kilohertz = createDecimalMeasure("Kilohertz", "kHz", "1000.0")
 
 val FrequencyGroup = MeasureGroup("Frequency", listOf(Hertz, Kilohertz), Hertz)
 
 /** Pressure group */
-val Pascal = createDecimalMeasure("Pascal", "Pa", 1.0)
-val Bar = createDecimalMeasure("Bar", "bar", 100000.0)
+val Pascal = createDecimalMeasure("Pascal", "Pa", "1.0")
+val Bar = createDecimalMeasure("Bar", "bar", "100000.0")
 val SoundPressureLevel = Measure<DecimalNumber>(
     "Sound Pressure Level",
     "dB SPL",
@@ -320,45 +321,45 @@ val SoundPressureLevel = Measure<DecimalNumber>(
     { DecimalNumber(20) * log10(it / DecimalNumber(0.00002)) }, BaseType.Decimal,
     MeasureDesc["Sound Pressure Level"]
 )
-val Atmosphere = createDecimalMeasure("Atmosphere", "atm", 101325.0)
-val KilogramPerSquareMetre = createDecimalMeasure("Kilogram per Square Metre", "kg/m^2", 9.80665)
+val Atmosphere = createDecimalMeasure("Atmosphere", "atm", "101325.0")
+val KilogramPerSquareMetre = createDecimalMeasure("Kilogram per Square Metre", "kg/m^2", "9.80665")
 
 val PressureGroup = MeasureGroup("Pressure", listOf(Pascal, Bar, SoundPressureLevel, Atmosphere, KilogramPerSquareMetre), Pascal)
 
 /** Density group */
-val KilogramPerCubicMetre = createDecimalMeasure("Kilogram per Cubic Metre", "kg/m^3", 1.0)
+val KilogramPerCubicMetre = createDecimalMeasure("Kilogram per Cubic Metre", "kg/m^3", "1.0")
 val DensityGroup = MeasureGroup("Density", listOf(KilogramPerCubicMetre), KilogramPerCubicMetre)
 
 /** RotationFrequency group */
-val RevolutionsPerMinute = createDecimalMeasure("Revolutions per Minute", "rpm", 1.0)
-val RevolutionsPerSecond = createDecimalMeasure("Revolutions per Second", "rps", 60.0)
+val RevolutionsPerMinute = createDecimalMeasure("Revolutions per Minute", "rpm", "1.0")
+val RevolutionsPerSecond = createDecimalMeasure("Revolutions per Second", "rps", "60.0")
 val RotationFrequencyGroup =
     MeasureGroup("Rotation Frequency", listOf(RevolutionsPerMinute, RevolutionsPerSecond), RevolutionsPerMinute)
 
 /** Torque group */
-val NewtonMetre = createDecimalMeasure("Newton-Metre", "Nm", 1.0)
+val NewtonMetre = createDecimalMeasure("Newton-Metre", "Nm", "1.0")
 val TorqueGroup = MeasureGroup("Torque", listOf(NewtonMetre), NewtonMetre)
 
 /** Acceleration group */
-val MetrePerSquareSecond = createDecimalMeasure("Metre per Square Second", "m/s^2", 1.0)
+val MetrePerSquareSecond = createDecimalMeasure("Metre per Square Second", "m/s^2", "1.0")
 val AccelerationGroup = MeasureGroup("Acceleration", listOf(MetrePerSquareSecond), MetrePerSquareSecond)
 
 /** Induction group */
-val Henry = createDecimalMeasure("Henry", "H", 1.0)
+val Henry = createDecimalMeasure("Henry", "H", "1.0")
 val InductionGroup = MeasureGroup("Induction", listOf(Henry), Henry)
 
 /** MagneticFluxDensity group */
-val Tesla = createDecimalMeasure("Tesla", "T", 1.0)
+val Tesla = createDecimalMeasure("Tesla", "T", "1.0")
 val MagneticFluxDensityGroup = MeasureGroup("Magnetic Flux Density", listOf(Tesla), Tesla)
 
 /** Volume Flow Rate group */
-val CubicMetrePerSecond = createDecimalMeasure("Cubic Metre Per Second", "(m^3)/s", 1.0)
-val CubicMetrePerHour = createDecimalMeasure("Cubic Metre Per Hour", "(m^3)/h", 0.000277778)
-val CubicCentimetrePerSecond = createDecimalMeasure("Cubic Centimetre Per Second", "(cm^3)/s", 0.000001)
-val MillilitrePerSecond = createDecimalMeasure("Millilitre Per Second", "ml/s", 0.000001)
-val MillilitrePerMinute = createDecimalMeasure("Millilitre Per Minute", "ml/min", 0.0000000166667)
-val LitrePerMinute = createDecimalMeasure("Litre Per Minute", "l/min", 0.0000166667)
-val LitrePerSecond = createDecimalMeasure("Litre Per Second", "l/s", 0.001)
+val CubicMetrePerSecond = createDecimalMeasure("Cubic Metre Per Second", "(m^3)/s", "1.0")
+val CubicMetrePerHour = createDecimalMeasure("Cubic Metre Per Hour", "(m^3)/h", "0.000277778")
+val CubicCentimetrePerSecond = createDecimalMeasure("Cubic Centimetre Per Second", "(cm^3)/s", "0.000001")
+val MillilitrePerSecond = createDecimalMeasure("Millilitre Per Second", "ml/s", "0.000001")
+val MillilitrePerMinute = createDecimalMeasure("Millilitre Per Minute", "ml/min", "0.0000000166667")
+val LitrePerMinute = createDecimalMeasure("Litre Per Minute", "l/min", "0.0000166667")
+val LitrePerSecond = createDecimalMeasure("Litre Per Second", "l/s", "0.001")
 
 val VolumeFlowRateGroup = MeasureGroup(
     "Volume Flow Rate",
@@ -375,37 +376,37 @@ val VolumeFlowRateGroup = MeasureGroup(
 )
 
 /** Time group */
-val Second = createDecimalMeasure("Second", "s", 1.0)
-val Minute = createDecimalMeasure("Minute", "min", 60.0)
-val Hour = createDecimalMeasure("Hour", "h", 3600.0)
-val Day = createDecimalMeasure("Day", "d", 24 * 3600.0)
+val Second = createDecimalMeasure("Second", "s", "1.0")
+val Minute = createDecimalMeasure("Minute", "min", "60.0")
+val Hour = createDecimalMeasure("Hour", "h", "3600.0")
+val Day = createDecimalMeasure("Day", "d", "86400.0")
 val TimeGroup = MeasureGroup("Time", listOf(Second, Minute, Hour, Day), Second)
 
 /** Quantity group */
-val Thing = createDecimalMeasure("Thing", "thing", 1.0)
+val Thing = createDecimalMeasure("Thing", "thing", "1.0")
 val QuantityGroup = MeasureGroup("Quantity", listOf(Thing), Thing)
 
 /** Percentage group */
-val Percentage = createDecimalMeasure("Percentage", "%", 1.0)
+val Percentage = createDecimalMeasure("Percentage", "%", "1.0")
 val PercentageGroup = MeasureGroup("Percentage", listOf(Percentage), Percentage)
 
 /** Human group */
-val Human = createDecimalMeasure("Human", "human", 1.0)
+val Human = createDecimalMeasure("Human", "human", "1.0")
 val HumanGroup = MeasureGroup("Human", listOf(Human), Human)
 
 /** UK money group */
-val Penny = createDecimalMeasure("Penny", "p", 0.01)
-val PoundMoney = createDecimalMeasure("Pound(money)", "£", 1.0)
+val Penny = createDecimalMeasure("Penny", "p", "0.01")
+val PoundMoney = createDecimalMeasure("Pound(money)", "£", "1.0")
 val UKMoneyGroup = MeasureGroup("UK Money Group", listOf(Penny, PoundMoney), PoundMoney)
 
 /** USA money group */
-val CentAmerican = createDecimalMeasure("Cent(USA)", "c", 0.01)
-val Dollar = createDecimalMeasure("Dollar", "$", 1.0)
+val CentAmerican = createDecimalMeasure("Cent(USA)", "c", "0.01")
+val Dollar = createDecimalMeasure("Dollar", "$", "1.0")
 val USAMoneyGroup = MeasureGroup("USA Money Group", listOf(CentAmerican, Dollar), Dollar)
 
 /** Euro money group */
-val CentEuropean = createDecimalMeasure("Cent(Europa)", "c", 0.01)
-val Euro = createDecimalMeasure("Euro", "€", 1.0)
+val CentEuropean = createDecimalMeasure("Cent(Europa)", "c", "0.01")
+val Euro = createDecimalMeasure("Euro", "€", "1.0")
 val EuroMoneyGroup = MeasureGroup("Euro Money Group", listOf(CentEuropean, Euro), Euro)
 
 /** Global */

--- a/common/src/main/kotlin/com/infowings/catalog/common/Measure.kt
+++ b/common/src/main/kotlin/com/infowings/catalog/common/Measure.kt
@@ -126,6 +126,9 @@ expect class DecimalNumber(value: String) {
     operator fun plus(other: DecimalNumber): DecimalNumber
     operator fun div(other: DecimalNumber): DecimalNumber
     fun pow(other: DecimalNumber): DecimalNumber
+
+    fun toPlainString(): String
+    override fun toString(): String
 }
 
 expect fun log10(num: DecimalNumber): DecimalNumber
@@ -177,6 +180,9 @@ class MeasureGroup<T>(
     val description: String? = MeasureGroupDesc[name]
 ) {
     val elementGroupMap = measureList.map { it.name to base }.toMap()
+
+    fun getMeasure(measureName: String): Measure<T> = measureList.find { it.name == measureName }
+            ?: throw IllegalStateException("No such measure ($measureName) in measure group ${this.name}")
 }
 
 
@@ -412,7 +418,7 @@ val Euro = createDecimalMeasure("Euro", "€", "1.0")
 val EuroMoneyGroup = MeasureGroup("Euro Money Group", listOf(CentEuropean, Euro), Euro)
 
 /** Global */
-val MeasureGroupMap = setOf<MeasureGroup<*>>(
+val MeasureGroupMap = setOf(
     LengthGroup,
     SpeedGroup,
     AreaGroup,

--- a/common/src/main/kotlin/com/infowings/catalog/common/ObjectData.kt
+++ b/common/src/main/kotlin/com/infowings/catalog/common/ObjectData.kt
@@ -40,6 +40,7 @@ data class DetailedObjectPropertyViewResponse(
 data class DetailedRootValueViewResponse(
     val id: String,
     val value: ValueDTO,
+    val measureSymbol: String?,
     val description: String?,
     val children: List<DetailedValueViewResponse>
 )
@@ -48,6 +49,7 @@ data class DetailedRootValueViewResponse(
 data class DetailedValueViewResponse(
     val id: String,
     val value: ValueDTO,
+    val measureSymbol: String?,
     val description: String?,
     val aspectProperty: AspectPropertyDataExtended,
     val children: List<DetailedValueViewResponse>
@@ -79,6 +81,7 @@ data class ObjectPropertyEditDetailsResponse(
 data class ValueTruncated(
     val id: String,
     val value: ValueDTO,
+    val measureName: String?,
     val description: String?,
     val propertyId: String?,
     val version: Int,

--- a/common/src/main/kotlin/com/infowings/catalog/common/objekt/Protocol.kt
+++ b/common/src/main/kotlin/com/infowings/catalog/common/objekt/Protocol.kt
@@ -150,3 +150,6 @@ data class ValueDeleteResponse(
 
 @Serializable
 data class Reference(val id: String, val version: Int)
+
+@Serializable
+data class ValueRecalculationResponse(val targetMeasure: String, val value: String)

--- a/common/src/main/kotlin/com/infowings/catalog/common/objekt/Protocol.kt
+++ b/common/src/main/kotlin/com/infowings/catalog/common/objekt/Protocol.kt
@@ -47,19 +47,7 @@ data class ValueCreateRequest(
     val aspectPropertyId: String? = null,
     val parentValueId: String? = null
 ) {
-
     fun toDTO() = ValueCreateRequestDTO(value.toDTO(), description, objectPropertyId, measureName, aspectPropertyId, parentValueId)
-
-    companion object {
-        fun root(value: ObjectValueData, description: String?, objectPropertyId: String, measureName: String? = null) = ValueCreateRequest(
-            value = value,
-            description = description,
-            objectPropertyId = objectPropertyId,
-            measureName = measureName,
-            aspectPropertyId = null,
-            parentValueId = null
-        )
-    }
 }
 
 @Serializable

--- a/common/src/main/kotlin/com/infowings/catalog/common/objekt/Protocol.kt
+++ b/common/src/main/kotlin/com/infowings/catalog/common/objekt/Protocol.kt
@@ -43,29 +43,19 @@ data class ValueCreateRequest(
     val value: ObjectValueData,
     val description: String?,
     val objectPropertyId: String,
-    val measureId: String?,
-    val aspectPropertyId: String?,
-    val parentValueId: String?
+    val measureName: String? = null,
+    val aspectPropertyId: String? = null,
+    val parentValueId: String? = null
 ) {
-    constructor(value: ObjectValueData, description: String?, objectPropertyId: String) : this(value, description, objectPropertyId, null, null, null)
 
-    constructor(value: ObjectValueData, description: String?, objectPropertyId: String, measureId: String) : this(
-        value,
-        description,
-        objectPropertyId,
-        measureId,
-        null,
-        null
-    )
-
-    fun toDTO() = ValueCreateRequestDTO(value.toDTO(), description, objectPropertyId, measureId, aspectPropertyId, parentValueId)
+    fun toDTO() = ValueCreateRequestDTO(value.toDTO(), description, objectPropertyId, measureName, aspectPropertyId, parentValueId)
 
     companion object {
-        fun root(value: ObjectValueData, description: String?, objectPropertyId: String, measureId: String? = null) = ValueCreateRequest(
+        fun root(value: ObjectValueData, description: String?, objectPropertyId: String, measureName: String? = null) = ValueCreateRequest(
             value = value,
             description = description,
             objectPropertyId = objectPropertyId,
-            measureId = measureId,
+            measureName = measureName,
             aspectPropertyId = null,
             parentValueId = null
         )
@@ -77,7 +67,7 @@ data class ValueCreateRequestDTO(
     val value: ValueDTO,
     val description: String?,
     val objectPropertyId: String,
-    val measureId: String?,
+    val measureName: String?,
     val aspectPropertyId: String?,
     val parentValueId: String?
 ) {
@@ -87,27 +77,29 @@ data class ValueCreateRequestDTO(
         objectPropertyId = objectPropertyId,
         aspectPropertyId = aspectPropertyId,
         parentValueId = parentValueId,
-        measureId = measureId
+        measureName = measureName
     )
 }
 
 data class ValueUpdateRequest(
     val valueId: String,
     val value: ObjectValueData,
+    val measureName: String?,
     val description: String?,
     val version: Int
 ) {
-    fun toDTO() = ValueUpdateRequestDTO(valueId, value.toDTO(), description, version)
+    fun toDTO() = ValueUpdateRequestDTO(valueId, value.toDTO(), measureName, description, version)
 }
 
 @Serializable
 data class ValueUpdateRequestDTO(
     val valueId: String,
     val value: ValueDTO,
+    val measureName: String?,
     val description: String?,
     val version: Int
 ) {
-    fun toRequest() = ValueUpdateRequest(valueId, value.toData(), description, version)
+    fun toRequest() = ValueUpdateRequest(valueId, value.toData(), measureName, description, version)
 }
 
 @Serializable
@@ -153,7 +145,7 @@ data class ValueChangeResponse(
     val id: String,
     val value: ValueDTO,
     val description: String?,
-    val measureId: String?,
+    val measureName: String?,
     val objectProperty: Reference,
     val aspectPropertyId: String?,
     val parentValue: Reference?,

--- a/frontend/src/main/kotlin/com/infowings/catalog/common/DecimalNumber.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/common/DecimalNumber.kt
@@ -11,6 +11,8 @@ actual class DecimalNumber actual constructor(val value: Double) {
     actual operator fun plus(other: DecimalNumber): DecimalNumber = DecimalNumber(value + other.value)
     actual operator fun div(other: DecimalNumber): DecimalNumber = DecimalNumber(value / other.value)
     actual fun pow(other: DecimalNumber): DecimalNumber = DecimalNumber(value.pow(other.value))
+
+    actual fun toPlainString() = toString()
 }
 
 actual fun log10(num: DecimalNumber): DecimalNumber = DecimalNumber(kotlin.math.log10(num.value))

--- a/frontend/src/main/kotlin/com/infowings/catalog/common/DecimalNumber.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/common/DecimalNumber.kt
@@ -4,6 +4,7 @@ import kotlin.math.pow
 
 actual class DecimalNumber actual constructor(val value: Double) {
     actual constructor(value: Int) : this(value.toDouble())
+    actual constructor(value: String) : this(value.toDouble())
 
     actual operator fun minus(other: DecimalNumber): DecimalNumber = DecimalNumber(value - other.value)
     actual operator fun times(other: DecimalNumber): DecimalNumber = DecimalNumber(value * other.value)

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/ObjectEditStructure.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/ObjectEditStructure.kt
@@ -37,7 +37,7 @@ data class ObjectPropertyEditModel(
     var description: String? = null,
     var aspect: AspectTree? = null,
     var values: MutableList<ObjectPropertyValueEditModel>? = ArrayList(),
-    var expanded: Boolean = false
+    var expanded: Boolean = true
 ) {
     constructor(response: ObjectPropertyEditDetailsResponse) : this(
         response.id,
@@ -84,7 +84,7 @@ data class ObjectPropertyValueEditModel(
     var value: ObjectValueData? = null,
     var measureName: String? = null,
     var description: String? = null,
-    var expanded: Boolean = false,
+    var expanded: Boolean = true,
     var valueGroups: MutableList<AspectPropertyValueGroupEditModel> = ArrayList()
 ) {
 
@@ -169,7 +169,7 @@ data class AspectPropertyValueEditModel(
     var value: ObjectValueData? = null,
     var measureName: String? = null,
     var description: String? = null,
-    var expanded: Boolean = false,
+    var expanded: Boolean = true,
     var children: MutableList<AspectPropertyValueGroupEditModel> = mutableListOf()
 ) {
     constructor(value: ValueTruncated, valueMap: Map<String, ValueTruncated>) : this(

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/ObjectEditStructure.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/ObjectEditStructure.kt
@@ -82,6 +82,7 @@ data class ObjectPropertyValueEditModel(
     val id: String? = null,
     var version: Int? = null,
     var value: ObjectValueData? = null,
+    var measureName: String? = null,
     var description: String? = null,
     var expanded: Boolean = false,
     var valueGroups: MutableList<AspectPropertyValueGroupEditModel> = ArrayList()
@@ -91,6 +92,7 @@ data class ObjectPropertyValueEditModel(
         id = value.id,
         version = value.version,
         value = value.value.toData(),
+        measureName = value.measureName,
         description = value.description,
         valueGroups = value.childrenIds
                 .map { valueMap[it] ?: error("Child value does not exist in supplied list of values") }
@@ -117,6 +119,7 @@ data class ObjectPropertyValueEditModel(
 
     fun mergeWith(value: ValueTruncated, valueMap: Map<String, ValueTruncated>): ObjectPropertyValueEditModel {
         this.value = value.value.toData()
+        this.measureName = value.measureName
         this.version = value.version
         val existingValuesMap = this.valueGroups.flatMap { it.values }.associateBy { it.id }
         valueGroups = value.childrenIds
@@ -164,6 +167,7 @@ data class AspectPropertyValueEditModel(
     val id: String? = null,
     var version: Int? = null,
     var value: ObjectValueData? = null,
+    var measureName: String? = null,
     var description: String? = null,
     var expanded: Boolean = false,
     var children: MutableList<AspectPropertyValueGroupEditModel> = mutableListOf()
@@ -172,6 +176,7 @@ data class AspectPropertyValueEditModel(
         id = value.id,
         version = value.version,
         value = value.value.toData(),
+        measureName = value.measureName,
         description = value.description,
         children = value.childrenIds
             .map { valueMap[it] ?: error("Child value does not exist in supplied list of values") }
@@ -202,6 +207,7 @@ fun AspectPropertyValueEditModel?.mergeWith(value: ValueTruncated, valueMap: Map
         AspectPropertyValueEditModel(value, valueMap)
     else {
         this.value = value.value.toData()
+        this.measureName = value.measureName
         this.version = value.version
         val existingValuesMap = this.children.flatMap { it.values }.associateBy { it.id }
         this.children = value.childrenIds

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/ObjectExternalApi.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/ObjectExternalApi.kt
@@ -43,3 +43,6 @@ suspend fun deleteProperty(id: String, force: Boolean): PropertyDeleteResponse =
 
 suspend fun deleteValue(id: String, force: Boolean): ValueDeleteResponse =
     JSON.parse(delete("/api/objects/value/${encodeURIComponent(id)}?force=$force"))
+
+suspend fun recalculateValue(fromMeasure: String, toMeasure: String, value: String): ValueRecalculationResponse =
+    JSON.parse(get("/api/objects/recalculateValue?from=${encodeURIComponent(fromMeasure)}&to=${encodeURIComponent(toMeasure)}&value=${encodeURIComponent(value)}"))

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/ObjectViewStructure.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/ObjectViewStructure.kt
@@ -41,6 +41,7 @@ data class ObjectPropertyViewModel(
 data class ObjectPropertyValueViewModel(
     val id: String,
     val value: ObjectValueData,
+    val measureSymbol: String?,
     val description: String?,
     val valueGroups: List<AspectPropertyValueGroupViewModel>,
     var expanded: Boolean = false
@@ -49,6 +50,7 @@ data class ObjectPropertyValueViewModel(
     constructor(objectPropertyValueDetailed: DetailedRootValueViewResponse) : this(
         id = objectPropertyValueDetailed.id,
         value = objectPropertyValueDetailed.value.toData(),
+        measureSymbol = objectPropertyValueDetailed.measureSymbol,
         description = objectPropertyValueDetailed.description,
         valueGroups = objectPropertyValueDetailed.children.groupBy { it.aspectProperty }.toList().map {
             AspectPropertyValueGroupViewModel(
@@ -75,6 +77,7 @@ data class AspectPropertyValueGroupViewModel(
 data class AspectPropertyValueViewModel(
     val id: String,
     val value: ObjectValueData,
+    val measureSymbol: String?,
     val description: String?,
     val children: List<AspectPropertyValueGroupViewModel>,
     var expanded: Boolean = false
@@ -83,6 +86,7 @@ data class AspectPropertyValueViewModel(
     constructor(propertyValue: DetailedValueViewResponse) : this(
         id = propertyValue.id,
         value = propertyValue.value.toData(),
+        measureSymbol = propertyValue.measureSymbol,
         description = propertyValue.description,
         children = propertyValue.children.groupBy { it.aspectProperty }.toList().map {
             AspectPropertyValueGroupViewModel(

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/ObjectEditApiModel.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/ObjectEditApiModel.kt
@@ -86,6 +86,7 @@ class ObjectEditApiModelComponent : RComponent<ObjectEditApiModelComponent.Props
                 ObjectValueData.NullValue.toDTO(),
                 null,
                 null,
+                null,
                 createPropertyResponse.rootValue.version,
                 emptyList()
             )
@@ -211,6 +212,7 @@ class ObjectEditApiModelComponent : RComponent<ObjectEditApiModelComponent.Props
         val valueDescriptor = ValueTruncated(
             id = response.id,
             value = response.value,
+            measureName = response.measureName,
             description = response.description,
             propertyId = response.aspectPropertyId,
             version = response.version,

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/ObjectEditApiModel.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/ObjectEditApiModel.kt
@@ -251,14 +251,24 @@ class ObjectEditApiModelComponent : RComponent<ObjectEditApiModelComponent.Props
             version = response.objectProperty.version,
             rootValues = this.rootValues.map {
                 when {
-                    it.id == response.id -> it.copy(value = response.value, version = response.version, description = response.description)
+                    it.id == response.id -> it.copy(
+                        value = response.value,
+                        measureName = response.measureName,
+                        version = response.version,
+                        description = response.description
+                    )
                     it.id == response.parentValue?.id -> it.copy(version = response.parentValue.version)
                     else -> it
                 }
             },
             valueDescriptors = this.valueDescriptors.map {
                 when {
-                    it.id == response.id -> it.copy(value = response.value, version = response.version, description = response.description)
+                    it.id == response.id -> it.copy(
+                        value = response.value,
+                        measureName = response.measureName,
+                        version = response.version,
+                        description = response.description
+                    )
                     it.id == response.parentValue?.id -> it.copy(version = response.parentValue.version)
                     else -> it
                 }

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/ObjectTreeEditModel.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/ObjectTreeEditModel.kt
@@ -110,7 +110,7 @@ class ObjectTreeEditModelComponent(props: Props) : RComponent<ObjectTreeEditMode
                     value = value,
                     description = description,
                     objectPropertyId = objectPropertyId,
-                    measureId = null,
+                    measureName = null,
                     aspectPropertyId = aspectPropertyId,
                     parentValueId = parentValueId
                 )
@@ -124,6 +124,7 @@ class ObjectTreeEditModelComponent(props: Props) : RComponent<ObjectTreeEditMode
                 ValueUpdateRequest(
                     valueId = valueId,
                     value = value,
+                    measureName = null,
                     description = description,
                     version = version
                 )

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/ObjectTreeEditModel.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/ObjectTreeEditModel.kt
@@ -1,7 +1,6 @@
 package com.infowings.catalog.objects.edit
 
 import com.infowings.catalog.common.ObjectEditDetailsResponse
-import com.infowings.catalog.common.ObjectValueData
 import com.infowings.catalog.common.objekt.*
 import com.infowings.catalog.objects.ObjectEditViewModel
 import com.infowings.catalog.objects.ObjectPropertyEditModel
@@ -23,8 +22,8 @@ interface ObjectTreeEditModel {
     fun createProperty(propertyEditModel: ObjectPropertyEditModel)
     fun updateProperty(propertyEditModel: ObjectPropertyEditModel)
     fun deleteProperty(propertyEditModel: ObjectPropertyEditModel)
-    fun createValue(value: ObjectValueData, description: String?, objectPropertyId: String, parentValueId: String?, aspectPropertyId: String?)
-    fun updateValue(valueId: String, value: ObjectValueData, description: String?, version: Int)
+    fun createValue(valueCreateRequest: ValueCreateRequest)
+    fun updateValue(valueUpdateRequest: ValueUpdateRequest)
     fun deleteValue(valueId: String)
 }
 
@@ -103,32 +102,15 @@ class ObjectTreeEditModelComponent(props: Props) : RComponent<ObjectTreeEditMode
         deleteEntity { force -> props.apiModel.deleteObjectProperty(propertyId, force) }
     }
 
-    override fun createValue(value: ObjectValueData, description: String?, objectPropertyId: String, parentValueId: String?, aspectPropertyId: String?) {
+    override fun createValue(valueCreateRequest: ValueCreateRequest) {
         launch {
-            props.apiModel.submitObjectValue(
-                ValueCreateRequest(
-                    value = value,
-                    description = description,
-                    objectPropertyId = objectPropertyId,
-                    measureName = null,
-                    aspectPropertyId = aspectPropertyId,
-                    parentValueId = parentValueId
-                )
-            )
+            props.apiModel.submitObjectValue(valueCreateRequest)
         }
     }
 
-    override fun updateValue(valueId: String, value: ObjectValueData, description: String?, version: Int) {
+    override fun updateValue(valueUpdateRequest: ValueUpdateRequest) {
         launch {
-            props.apiModel.editObjectValue(
-                ValueUpdateRequest(
-                    valueId = valueId,
-                    value = value,
-                    measureName = null,
-                    description = description,
-                    version = version
-                )
-            )
+            props.apiModel.editObjectValue(valueUpdateRequest)
         }
     }
 

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/AspectPropertiesEditList.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/AspectPropertiesEditList.kt
@@ -39,7 +39,7 @@ fun RBuilder.aspectPropertiesEditList(
                     attrs {
                         this.aspectProperty = aspectProperty
                         this.onCreateValue = if (editContext.currentContext == null) {
-                            { valueData ->
+                            { valueData, measureName ->
                                 editContext.setContext(EditNewChildContextModel)
                                 onAddValueGroup(
                                     AspectPropertyValueGroupEditModel(
@@ -47,7 +47,8 @@ fun RBuilder.aspectPropertiesEditList(
                                         values = mutableListOf(
                                             AspectPropertyValueEditModel(
                                                 id = null,
-                                                value = valueData
+                                                value = valueData,
+                                                measureName = measureName
                                             )
                                         )
                                     )
@@ -134,6 +135,7 @@ fun RBuilder.aspectPropertiesEditList(
                                     editContext.setContext(EditExistingContextModel(value.id))
                                     onUpdate(valueGroupIndex) {
                                         values[valueIndex].value = aspectProperty.aspect.defaultValue()
+                                        values[valueIndex].measureName = aspectProperty.aspect.measure
                                     }
                                 }
                             }
@@ -144,7 +146,8 @@ fun RBuilder.aspectPropertiesEditList(
                                         values.add(
                                             AspectPropertyValueEditModel(
                                                 id = null,
-                                                value = aspectProperty.aspect.defaultValue()
+                                                value = aspectProperty.aspect.defaultValue(),
+                                                measureName = aspectProperty.aspect.measure
                                             )
                                         )
                                     }
@@ -204,9 +207,9 @@ val aspectPropertyValueCreateNode = rFunction<AspectPropertyValueCreateNodeProps
                         cardinality = props.aspectProperty.cardinality
                         onCreateValue = props.onCreateValue?.let { onCreateValue ->
                             if (props.aspectProperty.cardinality == PropertyCardinality.ZERO) {
-                                { onCreateValue(ObjectValueData.NullValue) }
+                                { onCreateValue(ObjectValueData.NullValue, null) }
                             } else {
-                                { onCreateValue(props.aspectProperty.aspect.defaultValue()) }
+                                { onCreateValue(props.aspectProperty.aspect.defaultValue(), props.aspectProperty.aspect.measure) }
                             }
                         }
                     }
@@ -218,7 +221,7 @@ val aspectPropertyValueCreateNode = rFunction<AspectPropertyValueCreateNodeProps
 
 interface AspectPropertyValueCreateNodeProps : RProps {
     var aspectProperty: AspectPropertyTree
-    var onCreateValue: ((ObjectValueData?) -> Unit)?
+    var onCreateValue: ((value: ObjectValueData?, measureName: String?) -> Unit)?
 }
 
 val aspectPropertyValueEditNode = rFunction<AspectPropertyValueEditNodeProps>("AspectPropertyValueEditNode") { props ->

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/AspectPropertiesEditList.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/AspectPropertiesEditList.kt
@@ -267,20 +267,22 @@ val aspectPropertyValueEditNode = rFunction<AspectPropertyValueEditNodeProps>("A
                             }
                         }
                         onMeasureNameChanged = if (props.editContext.currentContext == null) {
-                            {
+                            { newMeasureName, objectValueData ->
                                 props.editContext.setContext(
                                     EditExistingContextModel(
                                         props.value.id ?: error("Value should have id != null in order to be edited")
                                     )
                                 )
                                 props.onUpdate {
-                                    measureName = it
+                                    measureName = newMeasureName
+                                    value = objectValueData
                                 }
                             }
                         } else {
-                            {
+                            { newMeasureName, objectValueData ->
                                 props.onUpdate {
-                                    measureName = it
+                                    measureName = newMeasureName
+                                    value = objectValueData
                                 }
                             }
                         }

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/ObjectPropertiesEditList.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/ObjectPropertiesEditList.kt
@@ -6,10 +6,7 @@ import com.infowings.catalog.common.objekt.ValueUpdateRequest
 import com.infowings.catalog.components.treeview.controlledTreeNode
 import com.infowings.catalog.objects.ObjectPropertyEditModel
 import com.infowings.catalog.objects.ObjectPropertyValueEditModel
-import com.infowings.catalog.objects.edit.EditContext
-import com.infowings.catalog.objects.edit.EditExistingContextModel
-import com.infowings.catalog.objects.edit.EditNewChildContextModel
-import com.infowings.catalog.objects.edit.ObjectTreeEditModel
+import com.infowings.catalog.objects.edit.*
 import com.infowings.catalog.objects.edit.tree.format.objectPropertyEditLineFormat
 import com.infowings.catalog.objects.edit.tree.format.objectPropertyValueEditLineFormat
 import react.RBuilder
@@ -184,8 +181,7 @@ fun RBuilder.objectPropertiesEditList(
                                 }
                             }
                             value.value == ObjectValueData.NullValue && !(property.aspect?.deleted ?: true) &&
-                                    ((value.id == null && currentEditContextModel == EditNewChildContextModel) ||
-                                            (value.id != null && currentEditContextModel == EditExistingContextModel(value.id))) -> {
+                                    isValueBeingEdited(value.id, currentEditContextModel) -> {
                                 {
                                     updater(propertyIndex) {
                                         val targetValue = (values ?: error("Must not be able to update value if there is no value"))[valueIndex]
@@ -263,6 +259,9 @@ fun RBuilder.objectPropertiesEditList(
         }
     }
 }
+
+private fun isValueBeingEdited(valueId: String?, editContextModel: EditContextModel?) =
+    (valueId == null && editContextModel == EditNewChildContextModel) || (valueId != null && editContextModel == EditExistingContextModel(valueId))
 
 val objectPropertyEditNode = rFunction<ObjectPropertyEditNodeProps>("ObjectPropertyEditNode") { props ->
     controlledTreeNode {

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/ObjectPropertiesEditList.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/ObjectPropertiesEditList.kt
@@ -184,13 +184,13 @@ fun RBuilder.objectPropertiesEditList(
                                 }
                             }
                             value.value == ObjectValueData.NullValue && !(property.aspect?.deleted ?: true) &&
-                                    ((value.id == null && currentEditContextModel == EditNewChildContextModel) || (value.id != null && currentEditContextModel == EditExistingContextModel(
-                                        value.id
-                                    ))) -> {
+                                    ((value.id == null && currentEditContextModel == EditNewChildContextModel) ||
+                                            (value.id != null && currentEditContextModel == EditExistingContextModel(value.id))) -> {
                                 {
                                     updater(propertyIndex) {
-                                        (values ?: error("Must not be able to update value if there is no value"))[valueIndex].value =
-                                                property.aspect?.defaultValue()
+                                        val targetValue = (values ?: error("Must not be able to update value if there is no value"))[valueIndex]
+                                        targetValue.value = property.aspect?.defaultValue()
+                                        targetValue.measureName = property.aspect?.measure
                                     }
                                 }
                             }
@@ -198,7 +198,9 @@ fun RBuilder.objectPropertiesEditList(
                                 {
                                     editContext.setContext(EditExistingContextModel(value.id ?: error("value should have id != null")))
                                     updater(propertyIndex) {
-                                        (values ?: error("Must not be able to update value if there is no value"))[valueIndex].value = property.aspect?.defaultValue()
+                                        val targetValue = (values ?: error("Must not be able to update value if there is no value"))[valueIndex]
+                                        targetValue.value = property.aspect?.defaultValue()
+                                        targetValue.measureName = property.aspect?.measure
                                     }
                                 }
                             }

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/ObjectPropertiesEditList.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/ObjectPropertiesEditList.kt
@@ -174,7 +174,7 @@ fun RBuilder.objectPropertiesEditList(
                                                 null,
                                                 null,
                                                 property.aspect?.defaultValue(),
-                                                null,
+                                                property.aspect?.measure,
                                                 null,
                                                 false,
                                                 mutableListOf()

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/ObjectPropertiesEditList.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/ObjectPropertiesEditList.kt
@@ -261,7 +261,7 @@ fun RBuilder.objectPropertiesEditList(
 }
 
 private fun isValueBeingEdited(valueId: String?, editContextModel: EditContextModel?) =
-    (valueId == null && editContextModel == EditNewChildContextModel) || (valueId != null && editContextModel == EditExistingContextModel(valueId))
+    valueId == null && editContextModel == EditNewChildContextModel || valueId != null && editContextModel == EditExistingContextModel(valueId)
 
 val objectPropertyEditNode = rFunction<ObjectPropertyEditNodeProps>("ObjectPropertyEditNode") { props ->
     controlledTreeNode {

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/ObjectPropertiesEditList.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/ObjectPropertiesEditList.kt
@@ -432,20 +432,22 @@ val objectPropertyValueEditNode = rFunction<ObjectPropertyValueEditNodeProps>("O
                             }
                         }
                         onValueMeasureNameChanged = if (props.editContext.currentContext == null) {
-                            {
+                            { newMeasureName, objectValueData ->
                                 props.editContext.setContext(
                                     EditExistingContextModel(
                                         props.rootValue.id ?: error("Root value should have id != null in order to edit")
                                     )
                                 )
                                 props.onValueUpdate {
-                                    measureName = it
+                                    measureName = newMeasureName
+                                    value = objectValueData
                                 }
                             }
                         } else {
-                            {
+                            { newMeasureName, objectValueData ->
                                 props.onValueUpdate {
-                                    measureName = it
+                                    measureName = newMeasureName
+                                    value = objectValueData
                                 }
                             }
                         }

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/format/AspectPropertyEditLineFormat.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/format/AspectPropertyEditLineFormat.kt
@@ -1,15 +1,13 @@
 package com.infowings.catalog.objects.edit.tree.format
 
-import com.infowings.catalog.common.BaseType
-import com.infowings.catalog.common.Measure
-import com.infowings.catalog.common.ObjectValueData
-import com.infowings.catalog.common.PropertyCardinality
+import com.infowings.catalog.common.*
 import com.infowings.catalog.components.buttons.cancelButtonComponent
 import com.infowings.catalog.components.buttons.minusButtonComponent
 import com.infowings.catalog.components.buttons.plusButtonComponent
 import com.infowings.catalog.components.description.descriptionComponent
 import com.infowings.catalog.components.submit.submitButtonComponent
 import com.infowings.catalog.objects.edit.tree.inputs.propertyValue
+import com.infowings.catalog.objects.edit.tree.inputs.valueMeasureSelect
 import react.RProps
 import react.dom.div
 import react.dom.span
@@ -46,9 +44,15 @@ val aspectPropertyEditLineFormat = rFunction<AspectPropertyEditLineFormatProps>(
                 disabled = props.disabled
             )
             props.aspectMeasure?.let {
-                span(classes = "aspect-property__property-measure") {
-                    +it.symbol
-                }
+                valueMeasureSelect(
+                    measureGroup = MeasureMeasureGroupMap[it.name] ?: error("No measure group for measure ${it.name}"),
+                    defaultMeasure = it,
+                    currentMeasure = props.valueMeasure,
+                    onMeasureSelected = { measure ->
+                        props.onMeasureNameChanged(measure?.name)
+                    },
+                    disabled = props.disabled
+                )
             }
         }
         if (props.disabled) {
@@ -88,7 +92,9 @@ interface AspectPropertyEditLineFormatProps : RProps {
     var subjectName: String?
     var recommendedCardinality: PropertyCardinality
     var value: ObjectValueData?
+    var valueMeasure: Measure<*>?
     var onChange: (ObjectValueData) -> Unit
+    var onMeasureNameChanged: (String?) -> Unit
     var valueDescription: String?
     var onDescriptionChange: (String) -> Unit
     var conformsToCardinality: Boolean

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/format/AspectPropertyEditLineFormat.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/format/AspectPropertyEditLineFormat.kt
@@ -52,7 +52,8 @@ val aspectPropertyEditLineFormat = rFunction<AspectPropertyEditLineFormatProps>(
                 } else {
                     valueMeasureSelect(
                         measureGroup = measureGroup,
-                        stringValueRepresentation = (props.value as ObjectValueData.DecimalValue).valueRepr,
+                        stringValueRepresentation = (value as? ObjectValueData.DecimalValue)?.valueRepr
+                                ?: error("Value has non-decimal type and has non-null measure"),
                         currentMeasure = props.valueMeasure ?: error("Value has no assigned measure"),
                         onMeasureSelected = { measure, stringValueRepresentation ->
                             props.onMeasureNameChanged(measure.name, ObjectValueData.DecimalValue(stringValueRepresentation))

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/format/AspectPropertyEditLineFormat.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/format/AspectPropertyEditLineFormat.kt
@@ -52,9 +52,10 @@ val aspectPropertyEditLineFormat = rFunction<AspectPropertyEditLineFormatProps>(
                 } else {
                     valueMeasureSelect(
                         measureGroup = measureGroup,
+                        stringValueRepresentation = (props.value as ObjectValueData.DecimalValue).valueRepr,
                         currentMeasure = props.valueMeasure ?: error("Value has no assigned measure"),
-                        onMeasureSelected = { measure ->
-                            props.onMeasureNameChanged(measure?.name)
+                        onMeasureSelected = { measure, stringValueRepresentation ->
+                            props.onMeasureNameChanged(measure.name, ObjectValueData.DecimalValue(stringValueRepresentation))
                         },
                         disabled = props.disabled
                     )
@@ -100,7 +101,7 @@ interface AspectPropertyEditLineFormatProps : RProps {
     var value: ObjectValueData?
     var valueMeasure: Measure<*>?
     var onChange: (ObjectValueData) -> Unit
-    var onMeasureNameChanged: (String?) -> Unit
+    var onMeasureNameChanged: (String?, ObjectValueData) -> Unit
     var valueDescription: String?
     var onDescriptionChange: (String) -> Unit
     var conformsToCardinality: Boolean

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/format/AspectPropertyEditLineFormat.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/format/AspectPropertyEditLineFormat.kt
@@ -52,8 +52,7 @@ val aspectPropertyEditLineFormat = rFunction<AspectPropertyEditLineFormatProps>(
                 } else {
                     valueMeasureSelect(
                         measureGroup = measureGroup,
-                        defaultMeasure = it,
-                        currentMeasure = props.valueMeasure,
+                        currentMeasure = props.valueMeasure ?: error("Value has no assigned measure"),
                         onMeasureSelected = { measure ->
                             props.onMeasureNameChanged(measure?.name)
                         },

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/format/AspectPropertyEditLineFormat.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/format/AspectPropertyEditLineFormat.kt
@@ -44,15 +44,22 @@ val aspectPropertyEditLineFormat = rFunction<AspectPropertyEditLineFormatProps>(
                 disabled = props.disabled
             )
             props.aspectMeasure?.let {
-                valueMeasureSelect(
-                    measureGroup = MeasureMeasureGroupMap[it.name] ?: error("No measure group for measure ${it.name}"),
-                    defaultMeasure = it,
-                    currentMeasure = props.valueMeasure,
-                    onMeasureSelected = { measure ->
-                        props.onMeasureNameChanged(measure?.name)
-                    },
-                    disabled = props.disabled
-                )
+                val measureGroup = MeasureMeasureGroupMap[it.name] ?: error("No measure group for measure ${it.name}")
+                if (measureGroup.measureList.size == 1) {
+                    span(classes = "aspect-property__property-measure") {
+                        +it.symbol
+                    }
+                } else {
+                    valueMeasureSelect(
+                        measureGroup = measureGroup,
+                        defaultMeasure = it,
+                        currentMeasure = props.valueMeasure,
+                        onMeasureSelected = { measure ->
+                            props.onMeasureNameChanged(measure?.name)
+                        },
+                        disabled = props.disabled
+                    )
+                }
             }
         }
         if (props.disabled) {

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/format/ObjectPropertyValueEditLineFormat.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/format/ObjectPropertyValueEditLineFormat.kt
@@ -2,6 +2,7 @@ package com.infowings.catalog.objects.edit.tree.format
 
 import com.infowings.catalog.common.BaseType
 import com.infowings.catalog.common.Measure
+import com.infowings.catalog.common.MeasureMeasureGroupMap
 import com.infowings.catalog.common.ObjectValueData
 import com.infowings.catalog.components.buttons.cancelButtonComponent
 import com.infowings.catalog.components.buttons.minusButtonComponent
@@ -10,6 +11,7 @@ import com.infowings.catalog.components.description.descriptionComponent
 import com.infowings.catalog.components.submit.submitButtonComponent
 import com.infowings.catalog.objects.edit.tree.inputs.name
 import com.infowings.catalog.objects.edit.tree.inputs.propertyValue
+import com.infowings.catalog.objects.edit.tree.inputs.valueMeasureSelect
 import react.RProps
 import react.dom.div
 import react.dom.span
@@ -60,9 +62,15 @@ val objectPropertyValueEditLineFormat = rFunction<ObjectPropertyValueEditLineFor
                 disabled = props.valueDisabled
             )
             props.aspectMeasure?.let {
-                span(classes = "property-value__aspect-measure") {
-                    +it.symbol
-                }
+                valueMeasureSelect(
+                    measureGroup = MeasureMeasureGroupMap[it.name] ?: error("No measure group for measure ${it.name}"),
+                    currentMeasure = props.valueMeasure,
+                    defaultMeasure = it,
+                    onMeasureSelected = { measure ->
+                        props.onValueMeasureNameChanged(measure?.name)
+                    },
+                    disabled = props.valueDisabled
+                )
             }
         }
         if (props.valueDisabled) {
@@ -104,10 +112,12 @@ interface ObjectPropertyValueEditLineFormatProps : RProps {
     var subjectName: String?
     var referenceBookId: String?
     var value: ObjectValueData?
+    var valueMeasure: Measure<*>?
     var valueDescription: String?
     var onValueDescriptionChanged: (String) -> Unit
     var onPropertyNameUpdate: (String) -> Unit
     var onValueUpdate: (ObjectValueData) -> Unit
+    var onValueMeasureNameChanged: (String?) -> Unit
     var onSaveValue: (() -> Unit)?
     var onAddValue: (() -> Unit)?
     var onCancelValue: (() -> Unit)?

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/format/ObjectPropertyValueEditLineFormat.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/format/ObjectPropertyValueEditLineFormat.kt
@@ -70,8 +70,7 @@ val objectPropertyValueEditLineFormat = rFunction<ObjectPropertyValueEditLineFor
                 } else {
                     valueMeasureSelect(
                         measureGroup = measureGroup,
-                        currentMeasure = props.valueMeasure,
-                        defaultMeasure = it,
+                        currentMeasure = props.valueMeasure ?: error("Value has no assigned measure"),
                         onMeasureSelected = { measure ->
                             props.onValueMeasureNameChanged(measure?.name)
                         },

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/format/ObjectPropertyValueEditLineFormat.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/format/ObjectPropertyValueEditLineFormat.kt
@@ -62,15 +62,22 @@ val objectPropertyValueEditLineFormat = rFunction<ObjectPropertyValueEditLineFor
                 disabled = props.valueDisabled
             )
             props.aspectMeasure?.let {
-                valueMeasureSelect(
-                    measureGroup = MeasureMeasureGroupMap[it.name] ?: error("No measure group for measure ${it.name}"),
-                    currentMeasure = props.valueMeasure,
-                    defaultMeasure = it,
-                    onMeasureSelected = { measure ->
-                        props.onValueMeasureNameChanged(measure?.name)
-                    },
-                    disabled = props.valueDisabled
-                )
+                val measureGroup = MeasureMeasureGroupMap[it.name] ?: error("No measure group for measure ${it.name}")
+                if (measureGroup.measureList.size == 1) {
+                    span(classes = "property-value__aspect-measure") {
+                        +it.symbol
+                    }
+                } else {
+                    valueMeasureSelect(
+                        measureGroup = measureGroup,
+                        currentMeasure = props.valueMeasure,
+                        defaultMeasure = it,
+                        onMeasureSelected = { measure ->
+                            props.onValueMeasureNameChanged(measure?.name)
+                        },
+                        disabled = props.valueDisabled
+                    )
+                }
             }
         }
         if (props.valueDisabled) {

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/format/ObjectPropertyValueEditLineFormat.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/format/ObjectPropertyValueEditLineFormat.kt
@@ -53,11 +53,12 @@ val objectPropertyValueEditLineFormat = rFunction<ObjectPropertyValueEditLineFor
         props.onCancelProperty?.let {
             cancelButtonComponent(it, "pt-small")
         }
-        if (props.value != ObjectValueData.NullValue) {
+        val value = props.value
+        if (value != ObjectValueData.NullValue) {
             propertyValue(
                 baseType = props.aspectBaseType,
                 referenceBookId = props.referenceBookId,
-                value = props.value,
+                value = value,
                 onChange = props.onValueUpdate,
                 disabled = props.valueDisabled
             )
@@ -70,7 +71,8 @@ val objectPropertyValueEditLineFormat = rFunction<ObjectPropertyValueEditLineFor
                 } else {
                     valueMeasureSelect(
                         measureGroup = measureGroup,
-                        stringValueRepresentation = (props.value as ObjectValueData.DecimalValue).valueRepr,
+                        stringValueRepresentation = (value as? ObjectValueData.DecimalValue)?.valueRepr
+                                ?: error("Value has non-decimal type and has non-null measure"),
                         currentMeasure = props.valueMeasure ?: error("Value has no assigned measure"),
                         onMeasureSelected = { measure, stringValueRepresentation ->
                             props.onValueMeasureNameChanged(measure.name, ObjectValueData.DecimalValue(stringValueRepresentation))

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/format/ObjectPropertyValueEditLineFormat.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/format/ObjectPropertyValueEditLineFormat.kt
@@ -70,9 +70,10 @@ val objectPropertyValueEditLineFormat = rFunction<ObjectPropertyValueEditLineFor
                 } else {
                     valueMeasureSelect(
                         measureGroup = measureGroup,
+                        stringValueRepresentation = (props.value as ObjectValueData.DecimalValue).valueRepr,
                         currentMeasure = props.valueMeasure ?: error("Value has no assigned measure"),
-                        onMeasureSelected = { measure ->
-                            props.onValueMeasureNameChanged(measure?.name)
+                        onMeasureSelected = { measure, stringValueRepresentation ->
+                            props.onValueMeasureNameChanged(measure.name, ObjectValueData.DecimalValue(stringValueRepresentation))
                         },
                         disabled = props.valueDisabled
                     )
@@ -123,7 +124,7 @@ interface ObjectPropertyValueEditLineFormatProps : RProps {
     var onValueDescriptionChanged: (String) -> Unit
     var onPropertyNameUpdate: (String) -> Unit
     var onValueUpdate: (ObjectValueData) -> Unit
-    var onValueMeasureNameChanged: (String?) -> Unit
+    var onValueMeasureNameChanged: (String, ObjectValueData) -> Unit
     var onSaveValue: (() -> Unit)?
     var onAddValue: (() -> Unit)?
     var onCancelValue: (() -> Unit)?

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/inputs/ValueMeasureSelect.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/inputs/ValueMeasureSelect.kt
@@ -2,16 +2,20 @@ package com.infowings.catalog.objects.edit.tree.inputs
 
 import com.infowings.catalog.common.Measure
 import com.infowings.catalog.common.MeasureGroup
+import com.infowings.catalog.objects.recalculateValue
+import com.infowings.catalog.wrappers.blueprint.Button
+import com.infowings.catalog.wrappers.blueprint.Popover
 import com.infowings.catalog.wrappers.select.SelectOption
 import com.infowings.catalog.wrappers.select.commonSelect
 import kotlinext.js.jsObject
-import react.RBuilder
-import react.RProps
-import react.rFunction
+import kotlinx.coroutines.experimental.launch
+import react.*
+import react.dom.div
+import react.dom.h5
 
 interface ValueMeasureOption : SelectOption {
     var label: String
-    var measure: Measure<*>?
+    var measure: Measure<*>
 }
 
 private fun valueMeasureOption(measure: Measure<*>): ValueMeasureOption = jsObject {
@@ -19,38 +23,122 @@ private fun valueMeasureOption(measure: Measure<*>): ValueMeasureOption = jsObje
     this.measure = measure
 }
 
-val valueMeasureSelectComponent = rFunction<ValueMeasureSelectComponentProps>("ValueMeasureSelectComponent") { props ->
-    val allOptions = props.measureGroup.measureList.map(::valueMeasureOption).toTypedArray()
-    commonSelect<ValueMeasureOption> {
-        attrs {
-            className = "value-measure-select"
-            value = valueMeasureOption(props.currentMeasure)
-            labelKey = "label"
-            valueKey = "label"
-            onChange = { props.onMeasureSelected(it.measure) }
-            options = allOptions
-            disabled = props.disabled
-            clearable = false
+class ValueMeasureSelectComponent : RComponent<ValueMeasureSelectComponent.Props, ValueMeasureSelectComponent.State>() {
+
+    private fun recalculationConfirmed() {
+        val oldMeasureName = props.currentMeasure.name
+        val newMeasure = state.nextMeasure
+        newMeasure?.let {
+            launch {
+                val newValueRepresentation = recalculateValue(oldMeasureName, it.name, props.stringValueRepresentation)
+                props.onMeasureSelected(it, newValueRepresentation.value)
+            }
+            setState {
+                nextMeasure = null
+            }
         }
+    }
+
+    private fun recalculationRejected() {
+        val newMeasure = state.nextMeasure
+        newMeasure?.let {
+            props.onMeasureSelected(it, props.stringValueRepresentation)
+            setState {
+                nextMeasure = null
+            }
+        }
+    }
+
+    private fun handleNewMeasureSelected(option: ValueMeasureOption) {
+        if (props.currentMeasure.name == option.measure.name) {
+            props.onMeasureSelected(option.measure, props.stringValueRepresentation)
+        } else {
+            setState {
+                nextMeasure = option.measure
+            }
+        }
+    }
+
+    override fun RBuilder.render() {
+        val allOptions = props.measureGroup.measureList.map(::valueMeasureOption).toTypedArray()
+        Popover {
+            attrs {
+                isOpen = state.nextMeasure != null
+                onInteraction = { nextOpenState ->
+                    if (nextOpenState == false) {
+                        setState {
+                            nextMeasure = null
+                        }
+                    }
+                }
+                content = buildElement { suggestRecalculationPopoverWindow(::recalculationConfirmed, ::recalculationRejected) }
+            }
+            commonSelect<ValueMeasureOption> {
+                attrs {
+                    className = "value-measure-select"
+                    value = valueMeasureOption(props.currentMeasure)
+                    labelKey = "label"
+                    valueKey = "label"
+                    onChange = ::handleNewMeasureSelected
+                    options = allOptions
+                    disabled = props.disabled || state.nextMeasure != null
+                    clearable = false
+                }
+            }
+        }
+    }
+
+    interface Props : RProps {
+        var measureGroup: MeasureGroup<*>
+        var stringValueRepresentation: String
+        var currentMeasure: Measure<*>
+        var onMeasureSelected: (Measure<*>, String) -> Unit
+        var disabled: Boolean
+    }
+
+    interface State : RState {
+        var nextMeasure: Measure<*>?
     }
 }
 
-interface ValueMeasureSelectComponentProps : RProps {
-    var measureGroup: MeasureGroup<*>
-    var currentMeasure: Measure<*>
-    var onMeasureSelected: (Measure<*>?) -> Unit
-    var disabled: Boolean
+fun RBuilder.suggestRecalculationPopoverWindow(
+    onConfirmRecalculation: () -> Unit,
+    onRejectRecalculation: () -> Unit
+) = div(classes = "recalculate-window") {
+    div(classes = "recalculate-window__header") {
+        h5 {
+            +"Recalculate value?"
+        }
+    }
+    div(classes = "recalculate-window__buttons") {
+        Button {
+            attrs {
+                className = "pt-small pt-intent-success"
+                onClick = { onConfirmRecalculation() }
+            }
+            +"Recalculate"
+        }
+        Button {
+            attrs {
+                className = "pt-small"
+                onClick = { onRejectRecalculation() }
+            }
+            +"No, I'll do it myself"
+        }
+    }
 }
 
 fun RBuilder.valueMeasureSelect(
     measureGroup: MeasureGroup<*>,
     currentMeasure: Measure<*>,
-    onMeasureSelected: (Measure<*>?) -> Unit,
+    stringValueRepresentation: String,
+    onMeasureSelected: (Measure<*>, String) -> Unit,
     disabled: Boolean
-) = valueMeasureSelectComponent {
+) = child(ValueMeasureSelectComponent::class) {
     attrs {
         this.measureGroup = measureGroup
         this.currentMeasure = currentMeasure
+        this.stringValueRepresentation = stringValueRepresentation
         this.onMeasureSelected = onMeasureSelected
         this.disabled = disabled
     }

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/inputs/ValueMeasureSelect.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/inputs/ValueMeasureSelect.kt
@@ -20,19 +20,13 @@ private fun valueMeasureOption(measure: Measure<*>): ValueMeasureOption = jsObje
 }
 
 val valueMeasureSelectComponent = rFunction<ValueMeasureSelectComponentProps>("ValueMeasureSelectComponent") { props ->
-    val allOptions = (props.measureGroup.measureList.map(::valueMeasureOption) + jsObject<ValueMeasureOption> {
-        label = "Default (${props.defaultMeasure.symbol})"
-        measure = null
-    }).toTypedArray()
+    val allOptions = props.measureGroup.measureList.map(::valueMeasureOption).toTypedArray()
     commonSelect<ValueMeasureOption> {
         attrs {
             className = "value-measure-select"
             val currentMeasure = props.currentMeasure
             value = when (currentMeasure) {
-                null -> jsObject {
-                    label = "Default (${props.defaultMeasure.symbol})"
-                    measure = null
-                }
+                null -> valueMeasureOption(props.defaultMeasure)
                 else -> valueMeasureOption(currentMeasure)
             }
             labelKey = "label"

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/inputs/ValueMeasureSelect.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/inputs/ValueMeasureSelect.kt
@@ -1,0 +1,70 @@
+package com.infowings.catalog.objects.edit.tree.inputs
+
+import com.infowings.catalog.common.Measure
+import com.infowings.catalog.common.MeasureGroup
+import com.infowings.catalog.wrappers.select.SelectOption
+import com.infowings.catalog.wrappers.select.commonSelect
+import kotlinext.js.jsObject
+import react.RBuilder
+import react.RProps
+import react.rFunction
+
+interface ValueMeasureOption : SelectOption {
+    var label: String
+    var measure: Measure<*>?
+}
+
+private fun valueMeasureOption(measure: Measure<*>): ValueMeasureOption = jsObject {
+    this.label = measure.symbol
+    this.measure = measure
+}
+
+val valueMeasureSelectComponent = rFunction<ValueMeasureSelectComponentProps>("ValueMeasureSelectComponent") { props ->
+    val allOptions = (props.measureGroup.measureList.map(::valueMeasureOption) + jsObject<ValueMeasureOption> {
+        label = "Default (${props.defaultMeasure.symbol})"
+        measure = null
+    }).toTypedArray()
+    commonSelect<ValueMeasureOption> {
+        attrs {
+            className = "value-measure-select"
+            val currentMeasure = props.currentMeasure
+            value = when (currentMeasure) {
+                null -> jsObject {
+                    label = "Default (${props.defaultMeasure.symbol})"
+                    measure = null
+                }
+                else -> valueMeasureOption(currentMeasure)
+            }
+            labelKey = "label"
+            valueKey = "label"
+            onChange = { props.onMeasureSelected(it.measure) }
+            options = allOptions
+            disabled = props.disabled
+            clearable = false
+        }
+    }
+}
+
+interface ValueMeasureSelectComponentProps : RProps {
+    var measureGroup: MeasureGroup<*>
+    var currentMeasure: Measure<*>?
+    var defaultMeasure: Measure<*>
+    var onMeasureSelected: (Measure<*>?) -> Unit
+    var disabled: Boolean
+}
+
+fun RBuilder.valueMeasureSelect(
+    measureGroup: MeasureGroup<*>,
+    currentMeasure: Measure<*>?,
+    defaultMeasure: Measure<*>,
+    onMeasureSelected: (Measure<*>?) -> Unit,
+    disabled: Boolean
+) = valueMeasureSelectComponent {
+    attrs {
+        this.measureGroup = measureGroup
+        this.currentMeasure = currentMeasure
+        this.defaultMeasure = defaultMeasure
+        this.onMeasureSelected = onMeasureSelected
+        this.disabled = disabled
+    }
+}

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/inputs/ValueMeasureSelect.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/inputs/ValueMeasureSelect.kt
@@ -24,11 +24,7 @@ val valueMeasureSelectComponent = rFunction<ValueMeasureSelectComponentProps>("V
     commonSelect<ValueMeasureOption> {
         attrs {
             className = "value-measure-select"
-            val currentMeasure = props.currentMeasure
-            value = when (currentMeasure) {
-                null -> valueMeasureOption(props.defaultMeasure)
-                else -> valueMeasureOption(currentMeasure)
-            }
+            value = valueMeasureOption(props.currentMeasure)
             labelKey = "label"
             valueKey = "label"
             onChange = { props.onMeasureSelected(it.measure) }
@@ -41,23 +37,20 @@ val valueMeasureSelectComponent = rFunction<ValueMeasureSelectComponentProps>("V
 
 interface ValueMeasureSelectComponentProps : RProps {
     var measureGroup: MeasureGroup<*>
-    var currentMeasure: Measure<*>?
-    var defaultMeasure: Measure<*>
+    var currentMeasure: Measure<*>
     var onMeasureSelected: (Measure<*>?) -> Unit
     var disabled: Boolean
 }
 
 fun RBuilder.valueMeasureSelect(
     measureGroup: MeasureGroup<*>,
-    currentMeasure: Measure<*>?,
-    defaultMeasure: Measure<*>,
+    currentMeasure: Measure<*>,
     onMeasureSelected: (Measure<*>?) -> Unit,
     disabled: Boolean
 ) = valueMeasureSelectComponent {
     attrs {
         this.measureGroup = measureGroup
         this.currentMeasure = currentMeasure
-        this.defaultMeasure = defaultMeasure
         this.onMeasureSelected = onMeasureSelected
         this.disabled = disabled
     }

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/object-tree-edit.scss
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/object-tree-edit.scss
@@ -95,6 +95,21 @@
   }
 }
 
+.recalculate-window {
+  width: 30rem;
+  padding: 1.5rem;
+
+  &__header {
+    display: flex;
+    justify-content: center;
+  }
+
+  &__buttons {
+    display: flex;
+    justify-content: space-around
+  }
+}
+
 .property-aspect-type {
   margin-right: 1rem;
 }

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/object-tree-edit.scss
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/object-tree-edit.scss
@@ -124,3 +124,7 @@
 .object-value-input__boolean.pt-switch {
   margin: 0;
 }
+
+.value-measure-select {
+  width: 15rem;
+}

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/view/tree/AspectPropertyValueViewNode.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/view/tree/AspectPropertyValueViewNode.kt
@@ -1,5 +1,6 @@
 package com.infowings.catalog.objects.view.tree
 
+import com.infowings.catalog.common.GlobalMeasureMap
 import com.infowings.catalog.components.treeview.controlledTreeNode
 import com.infowings.catalog.objects.AspectPropertyValueViewModel
 import com.infowings.catalog.objects.AspectPropertyViewModel
@@ -25,7 +26,9 @@ val aspectPropertyValueViewNode = rFunction<AspectPropertyValueViewNodeProps>("A
                         aspectName = props.aspectProperty.aspectName
                         value = props.value.value
                         valueDescription = props.value.description
-                        measure = props.aspectProperty.measure
+                        measureSymbol = props.value.measureSymbol ?: props.aspectProperty.measure?.let {
+                            (GlobalMeasureMap[it] ?: error("No measure $it")).symbol
+                        }
                     }
                 }
             }!!

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/view/tree/ObjectPropertyValueViewNode.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/view/tree/ObjectPropertyValueViewNode.kt
@@ -1,5 +1,6 @@
 package com.infowings.catalog.objects.view.tree
 
+import com.infowings.catalog.common.GlobalMeasureMap
 import com.infowings.catalog.components.treeview.controlledTreeNode
 import com.infowings.catalog.objects.ObjectPropertyValueViewModel
 import com.infowings.catalog.objects.ObjectPropertyViewModel
@@ -25,7 +26,9 @@ val objectPropertyValueViewNode = rFunction<ObjectPropertyValueViewNodeProps>("O
                         propertyDescription = props.property.description
                         value = props.value.value
                         valueDescription = props.value.description
-                        measure = props.property.aspect.measure
+                        measureSymbol = props.value.measureSymbol ?: props.property.aspect.measure?.let {
+                            (GlobalMeasureMap[it] ?: error("No measure $it")).symbol
+                        }
                     }
                 }
             }!!

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/view/tree/format/PropertyValueLineFormat.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/view/tree/format/PropertyValueLineFormat.kt
@@ -1,7 +1,5 @@
 package com.infowings.catalog.objects.view.tree.format
 
-import com.infowings.catalog.common.GlobalMeasureMap
-import com.infowings.catalog.common.LinkValueData
 import com.infowings.catalog.common.ObjectValueData
 import com.infowings.catalog.components.description.descriptionComponent
 import react.RProps
@@ -30,10 +28,10 @@ val objectPropertyValueLineFormat = rFunction<ObjectPropertyValueLineFormatProps
             }
         }
         valueFormat(props.value)
-        props.measure?.let {
+        props.measureSymbol?.let {
             if (props.value != ObjectValueData.NullValue) {
                 span(classes = "object-property-value-line__value-measure") {
-                    +(GlobalMeasureMap[it]?.symbol ?: error("No such measure"))
+                    +it
                 }
             }
         }
@@ -54,7 +52,7 @@ interface ObjectPropertyValueLineFormatProps : RProps {
     var aspectName: String
     var value: ObjectValueData
     var valueDescription: String?
-    var measure: String?
+    var measureSymbol: String?
 }
 
 val aspectPropertyValueLineFormat = rFunction<AspectPropertyValueLineFormatProps>("AspectPropertyValueLineFormat") { props ->
@@ -70,10 +68,10 @@ val aspectPropertyValueLineFormat = rFunction<AspectPropertyValueLineFormatProps
             +props.aspectName
         }
         valueFormat(props.value)
-        props.measure?.let {
+        props.measureSymbol?.let {
             if (props.value != ObjectValueData.NullValue) {
                 span(classes = "object-property-value-line__value-measure") {
-                    +(GlobalMeasureMap[it]?.symbol ?: error("No such measure"))
+                    +it
                 }
             }
         }
@@ -93,5 +91,5 @@ interface AspectPropertyValueLineFormatProps : RProps {
     var aspectName: String
     var value: ObjectValueData
     var valueDescription: String?
-    var measure: String?
+    var measureSymbol: String?
 }


### PR DESCRIPTION
* Value is recalculated on save/update to base measure according to recalculation rules.
* Measure MUST be present in value save/update requests. Its presence MUST be validated (including corner cases where `value == NullValue` and value has no measure (Base type is string perhaps)
* Measure MUST be present in all responses on value create/edit page. If there is no measure in vertex, the measure should be calculated (for backward compatibility)
* When editing value, the frontend should ask to recalculate value if the measure is changed. If the user agrees, the value is recalculated on server side, to base and then to required measure from base. If user declines the proposition to recalculate, value should not change.