### PR TITLE
294 - Show subjects in object properties, 279 - Display correct subject in object property aspect

### DIFF
--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectDaoService.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectDaoService.kt
@@ -3,7 +3,6 @@ package com.infowings.catalog.data.objekt
 import com.infowings.catalog.common.*
 import com.infowings.catalog.common.objekt.ObjectCreateRequest
 import com.infowings.catalog.common.objekt.ObjectUpdateRequest
-import com.infowings.catalog.data.aspect.OpenDomain
 import com.infowings.catalog.data.toMeasure
 import com.infowings.catalog.loggerFor
 import com.infowings.catalog.storage.*
@@ -107,12 +106,22 @@ class ObjectDaoService(private val db: OrientDatabase) {
                 DetailedRootValueViewResponse(
                     rootValue.id,
                     rootValue.toObjectPropertyValue().calculateObjectValueData().toDTO(),
-                    rootValue.measure?.toMeasure()?.symbol,
+                    rootValue.explicitMeasureSymbol(),
                     rootValue.description,
                     rootValue.children.map { it.toDetailedAspectPropertyValueResponse() }
                 )
             }
         }
+
+    private fun ObjectPropertyValueVertex.explicitMeasureSymbol(): String? {
+        val currentMeasureSymbol = this.measure?.toMeasure()?.symbol
+        return if (currentMeasureSymbol == null) {
+            val aspect = this.aspectProperty?.associatedAspect ?: this.objectProperty?.aspect
+            aspect?.measure?.symbol
+        } else {
+            currentMeasureSymbol
+        }
+    }
 
     private fun ObjectPropertyValueVertex.toDetailedAspectPropertyValueResponse(): DetailedValueViewResponse {
         val aspectProperty = this.aspectProperty ?: throw IllegalStateException("Object property with id ${this.id} has no associated aspect")
@@ -120,17 +129,13 @@ class ObjectDaoService(private val db: OrientDatabase) {
         return DetailedValueViewResponse(
             this.id,
             this.toObjectPropertyValue().calculateObjectValueData().toDTO(),
-            this.measure?.toMeasure()?.symbol,
+            this.explicitMeasureSymbol(),
             this.description,
             AspectPropertyDataExtended(
-                aspectProperty.id,
                 aspectProperty.name,
-                aspect.id,
-                aspectProperty.cardinality,
                 aspect.name,
-                aspect.measure?.name,
-                OpenDomain(BaseType.restoreBaseType(aspect.baseType)).toString(),
                 aspect.baseType ?: throw IllegalStateException("Aspect with id ${aspect.id} has no associated base type"),
+                aspect.subject?.name,
                 aspect.referenceBookRootVertex?.name
             ),
             this.children.map { it.toDetailedAspectPropertyValueResponse() }

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectDaoService.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectDaoService.kt
@@ -106,20 +106,18 @@ class ObjectDaoService(private val db: OrientDatabase) {
                 DetailedRootValueViewResponse(
                     rootValue.id,
                     rootValue.toObjectPropertyValue().calculateObjectValueData().toDTO(),
-                    rootValue.explicitMeasureSymbol(),
+                    rootValue.getOrCalculateMeasureSymbol(),
                     rootValue.description,
                     rootValue.children.map { it.toDetailedAspectPropertyValueResponse() }
                 )
             }
         }
 
-    private fun ObjectPropertyValueVertex.explicitMeasureSymbol(): String? {
+    private fun ObjectPropertyValueVertex.getOrCalculateMeasureSymbol(): String? {
         val currentMeasureSymbol = this.measure?.toMeasure()?.symbol
-        return if (currentMeasureSymbol == null) {
+        return currentMeasureSymbol ?: run {
             val aspect = this.aspectProperty?.associatedAspect ?: this.objectProperty?.aspect
             aspect?.measure?.symbol
-        } else {
-            currentMeasureSymbol
         }
     }
 
@@ -129,7 +127,7 @@ class ObjectDaoService(private val db: OrientDatabase) {
         return DetailedValueViewResponse(
             this.id,
             this.toObjectPropertyValue().calculateObjectValueData().toDTO(),
-            this.explicitMeasureSymbol(),
+            this.getOrCalculateMeasureSymbol(),
             this.description,
             AspectPropertyDataExtended(
                 aspectProperty.name,

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectService.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectService.kt
@@ -6,6 +6,7 @@ import com.infowings.catalog.common.objekt.*
 import com.infowings.catalog.data.MeasureService
 import com.infowings.catalog.data.SubjectService
 import com.infowings.catalog.data.aspect.AspectDaoService
+import com.infowings.catalog.data.aspect.AspectVertex
 import com.infowings.catalog.data.history.HistoryAware
 import com.infowings.catalog.data.history.HistoryContext
 import com.infowings.catalog.data.history.HistoryService
@@ -51,10 +52,24 @@ class ObjectService(
             propertyVertex.id,
             propertyVertex.name,
             propertyVertex.description,
-            propertyVertex.aspect?.toAspectData() ?: throw IllegalStateException("Object property ${propertyVertex.id} without aspect"),
+            propertyVertex.aspect.toAspectTruncated(),
             propertyVertex.cardinality.name,
             values
         )
+    }
+
+    private fun AspectVertex?.toAspectTruncated(): AspectTruncated {
+        if (this == null) {
+            throw NullPointerException("Aspect vertex is null")
+        } else {
+            return AspectTruncated(
+                this.id,
+                this.name,
+                this.baseTypeStrict,
+                this.referenceBookRootVertex?.name,
+                this.subject?.name
+            )
+        }
     }
 
     fun getDetailedObjectForEdit(id: String) =

--- a/common/src/main/kotlin/com/infowings/catalog/common/AspectData.kt
+++ b/common/src/main/kotlin/com/infowings/catalog/common/AspectData.kt
@@ -60,14 +60,10 @@ data class AspectPropertyData(
 /** Data about AspectProperty together with data about relevant aspect */
 @Serializable
 data class AspectPropertyDataExtended(
-    val id: String,
     val name: String?,
-    val aspectId: String,
-    val cardinality: String,
     val aspectName: String,
-    val aspectMeasure: String?,
-    val aspectDomain: String,
     val aspectBaseType: String,
+    val aspectSubjectName: String?,
     val refBookName: String?
 )
 

--- a/common/src/main/kotlin/com/infowings/catalog/common/ObjectData.kt
+++ b/common/src/main/kotlin/com/infowings/catalog/common/ObjectData.kt
@@ -31,7 +31,7 @@ data class DetailedObjectPropertyViewResponse(
     val id: String,
     val name: String?,
     val description: String?,
-    val aspect: AspectData,
+    val aspect: AspectTruncated,
     val cardinality: String,
     val values: List<DetailedRootValueViewResponse>
 )
@@ -86,4 +86,13 @@ data class ValueTruncated(
     val propertyId: String?,
     val version: Int,
     val childrenIds: List<String>
+)
+
+@Serializable
+data class AspectTruncated(
+    val id: String,
+    val name: String,
+    val baseType: String,
+    val referenceBookName: String?,
+    val subjectName: String?
 )

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/ObjectViewStructure.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/ObjectViewStructure.kt
@@ -25,7 +25,7 @@ data class ObjectPropertyViewModel(
     val name: String?,
     val cardinality: PropertyCardinality,
     val description: String?,
-    val aspect: AspectData,
+    val aspect: AspectTruncated,
     val values: List<ObjectPropertyValueViewModel>
 ) {
     constructor(objectPropertyView: DetailedObjectPropertyViewResponse) : this(
@@ -105,37 +105,25 @@ data class AspectPropertyValueViewModel(
 }
 
 data class AspectPropertyViewModel(
-    val propertyId: String,
-    val aspectId: String,
-    val cardinality: PropertyCardinality,
     val roleName: String?,
     val aspectName: String,
-    val measure: String?,
     val baseType: String,
-    val domain: String,
-    val refBookName: String?
+    val refBookName: String?,
+    val subjectName: String?
 ) {
     constructor(aspectPropertyData: AspectPropertyDataExtended) : this(
-        aspectPropertyData.id,
-        aspectPropertyData.aspectId,
-        PropertyCardinality.valueOf(aspectPropertyData.cardinality),
         aspectPropertyData.name,
         aspectPropertyData.aspectName,
-        aspectPropertyData.aspectMeasure,
         aspectPropertyData.aspectBaseType,
-        aspectPropertyData.aspectDomain,
-        aspectPropertyData.refBookName
+        aspectPropertyData.refBookName,
+        aspectPropertyData.aspectSubjectName
     )
 
     fun toExtendedPropertyData() = AspectPropertyDataExtended(
-        id = propertyId,
         name = roleName ?: "",
-        cardinality = cardinality.name,
-        aspectId = aspectId,
         aspectName = aspectName,
-        aspectMeasure = measure,
-        aspectDomain = domain,
         aspectBaseType = baseType,
+        aspectSubjectName = subjectName,
         refBookName = refBookName
     )
 }

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/format/ObjectPropertyEditLineFormat.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/edit/tree/format/ObjectPropertyEditLineFormat.kt
@@ -24,7 +24,7 @@ val objectPropertyEditLineFormat = rFunction<ObjectPropertyEditLineFormatProps>(
         )
         propertyAspect(
             value = props.aspect?.let { ShortAspectDescriptor(it.id, it.name, it.subjectName) },
-            onSelect = { props.onAspectChanged(AspectTree(id = it.id, name = it.name)) },
+            onSelect = { props.onAspectChanged(AspectTree(id = it.id, name = it.name, subjectName = it.subject)) },
             disabled = props.disabled || props.onAddValue != null // If onAddValue exists, it means the property has id.
             // API does not allow editing aspect, so it is better to just disable the option.
         )

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/view/tree/AspectPropertyValueViewNode.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/view/tree/AspectPropertyValueViewNode.kt
@@ -1,6 +1,5 @@
 package com.infowings.catalog.objects.view.tree
 
-import com.infowings.catalog.common.GlobalMeasureMap
 import com.infowings.catalog.components.treeview.controlledTreeNode
 import com.infowings.catalog.objects.AspectPropertyValueViewModel
 import com.infowings.catalog.objects.AspectPropertyViewModel
@@ -26,9 +25,8 @@ val aspectPropertyValueViewNode = rFunction<AspectPropertyValueViewNodeProps>("A
                         aspectName = props.aspectProperty.aspectName
                         value = props.value.value
                         valueDescription = props.value.description
-                        measureSymbol = props.value.measureSymbol ?: props.aspectProperty.measure?.let {
-                            (GlobalMeasureMap[it] ?: error("No measure $it")).symbol
-                        }
+                        measureSymbol = props.value.measureSymbol
+                        subjectName = props.aspectProperty.subjectName
                     }
                 }
             }!!

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/view/tree/ObjectPropertyValueViewNode.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/view/tree/ObjectPropertyValueViewNode.kt
@@ -1,6 +1,5 @@
 package com.infowings.catalog.objects.view.tree
 
-import com.infowings.catalog.common.GlobalMeasureMap
 import com.infowings.catalog.components.treeview.controlledTreeNode
 import com.infowings.catalog.objects.ObjectPropertyValueViewModel
 import com.infowings.catalog.objects.ObjectPropertyViewModel
@@ -26,9 +25,8 @@ val objectPropertyValueViewNode = rFunction<ObjectPropertyValueViewNodeProps>("O
                         propertyDescription = props.property.description
                         value = props.value.value
                         valueDescription = props.value.description
-                        measureSymbol = props.value.measureSymbol ?: props.property.aspect.measure?.let {
-                            (GlobalMeasureMap[it] ?: error("No measure $it")).symbol
-                        }
+                        measureSymbol = props.value.measureSymbol
+                        subjectName = props.property.aspect.subjectName
                     }
                 }
             }!!

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/view/tree/format/PropertyValueLineFormat.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/view/tree/format/PropertyValueLineFormat.kt
@@ -19,6 +19,9 @@ val objectPropertyValueLineFormat = rFunction<ObjectPropertyValueLineFormatProps
         span(classes = "text-bold object-property-value-line__aspect-name") {
             +props.aspectName
         }
+        span(classes = "object-property-value-line__aspect-subject-name") {
+            +"(${props.subjectName ?: "Global"})"
+        }
         props.propertyDescription?.let {
             if (it.isNotBlank()) {
                 descriptionComponent(
@@ -53,6 +56,7 @@ interface ObjectPropertyValueLineFormatProps : RProps {
     var value: ObjectValueData
     var valueDescription: String?
     var measureSymbol: String?
+    var subjectName: String?
 }
 
 val aspectPropertyValueLineFormat = rFunction<AspectPropertyValueLineFormatProps>("AspectPropertyValueLineFormat") { props ->
@@ -66,6 +70,9 @@ val aspectPropertyValueLineFormat = rFunction<AspectPropertyValueLineFormatProps
         }
         span(classes = "text-bold object-property-value-line__aspect-name") {
             +props.aspectName
+        }
+        span(classes = "object-property-value-line__aspect-subject-name") {
+            +"(${props.subjectName ?: "Global"})"
         }
         valueFormat(props.value)
         props.measureSymbol?.let {
@@ -92,4 +99,5 @@ interface AspectPropertyValueLineFormatProps : RProps {
     var value: ObjectValueData
     var valueDescription: String?
     var measureSymbol: String?
+    var subjectName: String?
 }

--- a/frontend/src/main/kotlin/com/infowings/catalog/objects/view/tree/object-tree-view.scss
+++ b/frontend/src/main/kotlin/com/infowings/catalog/objects/view/tree/object-tree-view.scss
@@ -33,25 +33,12 @@
   display: flex;
   align-items: center;
 
-  &__role-name {
-    margin-right: 1rem;
-  }
-
-  &__aspect-name {
+  & > * {
     margin-right: 1rem;
   }
 
   &__property-description {
     height: 1.6rem;
-    margin-right: 1rem;
-  }
-
-  &__value {
-    margin-right: 1rem;
-  }
-
-  &__value-measure {
-    margin-right: 1rem;
   }
 
   &__value-description {


### PR DESCRIPTION
* Changed API on object view page in order to get subjects along with aspects.
* Fixed the displayed subject when choosing aspect.