### PR TITLE
250 - Aspect property linked entity warning, 287 - Aspect business key verification fix, 288 - Aspect page property rendering issues fix

### DIFF
--- a/backend/src/main/kotlin/com/infowings/catalog/data/aspect/AspectDaoService.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/aspect/AspectDaoService.kt
@@ -314,7 +314,7 @@ class AspectDaoService(private val db: OrientDatabase, private val measureServic
         val baseQuery = if (id != null) selectWithNameDifferentId else selectWithName
 
         val q = if (subjectId == null) {
-            baseQuery
+            "$baseQuery and OUT(\"$ASPECT_SUBJECT_EDGE\").size() = 0"
         } else {
             "$baseQuery and (@rid in (select out.@rid from $ASPECT_SUBJECT_EDGE WHERE in.@rid = :subjectId))"
         }

--- a/backend/src/main/kotlin/com/infowings/catalog/data/aspect/AspectOVertexExtensions.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/aspect/AspectOVertexExtensions.kt
@@ -272,7 +272,7 @@ class AspectPropertyVertex(private val vertex: OVertex) : HistoryAware, OVertex 
         }
 
     val associatedAspect: AspectVertex
-        get() = vertex.getVertices(ODirection.OUT, ASPECT_ASPECT_PROPERTY_EDGE).first().toAspectVertex()
+        get() = vertex.getVertices(ODirection.OUT, ASPECT_ASPECT_PROPERTY_EDGE).single().toAspectVertex()
 
     fun isLinkedBy() = hasIncomingEdges(OBJECT_VALUE_ASPECT_PROPERTY_EDGE, OBJECT_VALUE_REF_ASPECT_PROPERTY_EDGE)
 

--- a/backend/src/main/kotlin/com/infowings/catalog/data/aspect/AspectOperationResults.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/aspect/AspectOperationResults.kt
@@ -1,0 +1,7 @@
+package com.infowings.catalog.data.aspect
+
+data class AspectPropertyDeleteResult(
+    val aspectPropertyVertex: AspectPropertyVertex,
+    val parentAspectVertex: AspectVertex,
+    val childAspectVertex: AspectVertex
+)

--- a/backend/src/main/kotlin/com/infowings/catalog/data/aspect/AspectOperationResults.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/aspect/AspectOperationResults.kt
@@ -1,8 +1,23 @@
 @file:Suppress("MatchingDeclarationName") // TODO: Remove @Suppress when more classes will be in the file
 package com.infowings.catalog.data.aspect
 
+import com.infowings.catalog.common.AspectPropertyDeleteResponse
+import com.infowings.catalog.common.PropertyCardinality
+import com.infowings.catalog.common.objekt.Reference
+import com.infowings.catalog.storage.id
+
 data class AspectPropertyDeleteResult(
     val aspectPropertyVertex: AspectPropertyVertex,
     val parentAspectVertex: AspectVertex,
     val childAspectVertex: AspectVertex
-)
+) {
+
+    fun toResponse() = AspectPropertyDeleteResponse(
+        this.aspectPropertyVertex.id,
+        PropertyCardinality.valueOf(this.aspectPropertyVertex.cardinality),
+        this.aspectPropertyVertex.name,
+        Reference(this.parentAspectVertex.id, this.parentAspectVertex.version),
+        Reference(this.childAspectVertex.id, this.childAspectVertex.version)
+    )
+
+}

--- a/backend/src/main/kotlin/com/infowings/catalog/data/aspect/AspectOperationResults.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/aspect/AspectOperationResults.kt
@@ -1,6 +1,6 @@
+@file:Suppress("MatchingDeclarationName") // TODO: Remove @Suppress when more classes will be in the file
 package com.infowings.catalog.data.aspect
 
-@Suppress("MatchingDeclarationName")
 data class AspectPropertyDeleteResult(
     val aspectPropertyVertex: AspectPropertyVertex,
     val parentAspectVertex: AspectVertex,

--- a/backend/src/main/kotlin/com/infowings/catalog/data/aspect/AspectOperationResults.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/aspect/AspectOperationResults.kt
@@ -1,5 +1,6 @@
 package com.infowings.catalog.data.aspect
 
+@Suppress("MatchingDeclarationName")
 data class AspectPropertyDeleteResult(
     val aspectPropertyVertex: AspectPropertyVertex,
     val parentAspectVertex: AspectVertex,

--- a/backend/src/main/kotlin/com/infowings/catalog/data/aspect/AspectService.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/aspect/AspectService.kt
@@ -14,7 +14,6 @@ import com.infowings.catalog.storage.transaction
 import com.orientechnologies.orient.core.id.ORecordId
 import com.orientechnologies.orient.core.record.ODirection
 
-
 interface AspectService {
     fun save(aspectData: AspectData, username: String): AspectData
     fun remove(aspectData: AspectData, username: String, force: Boolean = false)
@@ -211,9 +210,7 @@ class DefaultAspectService(
                     historyService.storeFact(propertySoftDeleteFact)
                     aspectDaoService.fakeRemove(aspectPropertyVertex)
                 }
-                aspectPropertyIsLinked && !force -> {
-                    throw AspectPropertyIsLinkedByValue(aspectPropertyVertex.id)
-                }
+                aspectPropertyIsLinked && !force -> throw AspectPropertyIsLinkedByValue(aspectPropertyVertex.id)
                 else -> {
                     val aspectSnapshot = parentAspectVertex.currentSnapshot()
 

--- a/backend/src/main/kotlin/com/infowings/catalog/data/aspect/AspectService.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/aspect/AspectService.kt
@@ -2,7 +2,6 @@ package com.infowings.catalog.data.aspect
 
 import com.infowings.catalog.auth.user.UserService
 import com.infowings.catalog.common.*
-import com.infowings.catalog.common.objekt.Reference
 import com.infowings.catalog.data.history.HistoryContext
 import com.infowings.catalog.data.history.HistoryFactWrite
 import com.infowings.catalog.data.history.HistoryService
@@ -226,14 +225,6 @@ class DefaultAspectService(
 
         return removePropertyResult.toResponse()
     }
-
-    private fun AspectPropertyDeleteResult.toResponse() = AspectPropertyDeleteResponse(
-        this.aspectPropertyVertex.id,
-        PropertyCardinality.valueOf(this.aspectPropertyVertex.cardinality),
-        this.aspectPropertyVertex.name,
-        Reference(this.parentAspectVertex.id, this.parentAspectVertex.version),
-        Reference(this.childAspectVertex.id, this.childAspectVertex.version)
-    )
 
     /**
      * Search [AspectData] by it's name

--- a/backend/src/main/kotlin/com/infowings/catalog/data/aspect/AspectService.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/aspect/AspectService.kt
@@ -2,6 +2,7 @@ package com.infowings.catalog.data.aspect
 
 import com.infowings.catalog.auth.user.UserService
 import com.infowings.catalog.common.*
+import com.infowings.catalog.common.objekt.Reference
 import com.infowings.catalog.data.history.HistoryContext
 import com.infowings.catalog.data.history.HistoryFactWrite
 import com.infowings.catalog.data.history.HistoryService
@@ -11,11 +12,13 @@ import com.infowings.catalog.loggerFor
 import com.infowings.catalog.storage.*
 import com.infowings.catalog.storage.transaction
 import com.orientechnologies.orient.core.id.ORecordId
+import com.orientechnologies.orient.core.record.ODirection
 
 
 interface AspectService {
     fun save(aspectData: AspectData, username: String): AspectData
     fun remove(aspectData: AspectData, username: String, force: Boolean = false)
+    fun removeProperty(aspectPropertyId: String, username: String, force: Boolean = false): AspectPropertyDeleteResponse
     fun findByName(name: String): Set<AspectData>
     fun getAspects(orderBy: List<AspectOrderBy> = listOf(AspectOrderBy(AspectSortField.NAME, Direction.ASC)), query: String? = null): List<AspectData>
     fun findById(id: String): AspectData
@@ -183,6 +186,57 @@ class DefaultAspectService(
             }
         }
     }
+
+    /**
+     * Removes [AspectPropertyVertex] if it is not linked.
+     * Marks [AspectPropertyVertex] as removed if it is linked and [force] is true.
+     * @param aspectPropertyId [AspectPropertyVertex.id] of corresponding [AspectPropertyVertex]
+     * @param force Flag that allows to mark [AspectPropertyVertex] as removed by setting its [AspectPropertyVertex.deleted] flag to true if
+     * [AspectPropertyVertex] is linked
+     */
+    override fun removeProperty(aspectPropertyId: String, username: String, force: Boolean): AspectPropertyDeleteResponse {
+        val removePropertyResult = transaction(db) {
+            val userVertex = userService.findUserVertexByUsername(username)
+            val historyContext = HistoryContext(userVertex)
+
+            val aspectPropertyVertex = aspectDaoService.findProperty(aspectPropertyId) ?: throw AspectPropertyDoesNotExist(aspectPropertyId)
+            val aspectPropertyIsLinked = aspectPropertyVertex.isLinkedBy()
+
+            val parentAspectVertex = aspectPropertyVertex.getVertices(ODirection.IN, ASPECT_ASPECT_PROPERTY_EDGE).single().toAspectVertex()
+            val childAspectVertex = aspectPropertyVertex.associatedAspect
+
+            when {
+                aspectPropertyIsLinked && force -> {
+                    val propertySoftDeleteFact = aspectPropertyVertex.toSoftDeleteFact(historyContext)
+                    historyService.storeFact(propertySoftDeleteFact)
+                    aspectDaoService.fakeRemove(aspectPropertyVertex)
+                }
+                aspectPropertyIsLinked && !force -> {
+                    throw AspectPropertyIsLinkedByValue(aspectPropertyVertex.id)
+                }
+                else -> {
+                    val aspectSnapshot = parentAspectVertex.currentSnapshot()
+
+                    val propertyDeleteFact = aspectPropertyVertex.toDeleteFact(historyContext)
+                    historyService.storeFact(propertyDeleteFact)
+                    aspectDaoService.remove(aspectPropertyVertex)
+
+                    historyService.storeFact(parentAspectVertex.toUpdateFact(historyContext, aspectSnapshot))
+                }
+            }
+            AspectPropertyDeleteResult(aspectPropertyVertex, parentAspectVertex, childAspectVertex)
+        }
+
+        return removePropertyResult.toResponse()
+    }
+
+    private fun AspectPropertyDeleteResult.toResponse() = AspectPropertyDeleteResponse(
+        this.aspectPropertyVertex.id,
+        PropertyCardinality.valueOf(this.aspectPropertyVertex.cardinality),
+        this.aspectPropertyVertex.name,
+        Reference(this.parentAspectVertex.id, this.parentAspectVertex.version),
+        Reference(this.childAspectVertex.id, this.childAspectVertex.version)
+    )
 
     /**
      * Search [AspectData] by it's name
@@ -402,5 +456,7 @@ class AspectCyclicDependencyException(cyclicIds: List<String>) :
 class AspectNameCannotBeNull : AspectException()
 class AspectHasLinkedEntitiesException(val id: String) : AspectException("Some entities refer to aspect $id")
 class AspectInconsistentStateException(message: String) : AspectException(message)
+
+class AspectPropertyIsLinkedByValue(val id: String) : AspectException("Aspect property with id $id is linked by value")
 
 class AspectEmptyChangeException : AspectException()

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectProperty.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectProperty.kt
@@ -1,6 +1,5 @@
 package com.infowings.catalog.data.objekt
 
-import com.infowings.catalog.common.PropertyCardinality
 import com.infowings.catalog.common.objekt.PropertyCreateResponse
 import com.infowings.catalog.common.objekt.PropertyDeleteResponse
 import com.infowings.catalog.common.objekt.PropertyUpdateResponse

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectProperty.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectProperty.kt
@@ -1,6 +1,10 @@
 package com.infowings.catalog.data.objekt
 
 import com.infowings.catalog.common.PropertyCardinality
+import com.infowings.catalog.common.objekt.PropertyCreateResponse
+import com.infowings.catalog.common.objekt.PropertyDeleteResponse
+import com.infowings.catalog.common.objekt.PropertyUpdateResponse
+import com.infowings.catalog.common.objekt.Reference
 import com.infowings.catalog.data.aspect.AspectPropertyVertex
 import com.infowings.catalog.data.aspect.AspectVertex
 import com.infowings.catalog.storage.description
@@ -30,69 +34,37 @@ data class PropertyCreateResult(
     private val objectVertex: ObjectVertex,
     private val rootValueVertex: ObjectPropertyValueVertex
 ) {
-    val id: String
-        get() = propertyVertex.id
 
-    val objectId: String
-        get() = objectVertex.id
-
-    val objectVersion: Int
-        get() = objectVertex.version
-
-    val rootValueId: String
-        get() = rootValueVertex.id
-
-    val rootValueVersion: Int
-        get() = rootValueVertex.version
-
-    val name: String?
-        get() = propertyVertex.name
-
-    val description: String?
-        get() = propertyVertex.description
-
-    val version: Int
-        get() = propertyVertex.version
+    fun toResponse() = PropertyCreateResponse(
+        propertyVertex.id,
+        Reference(objectVertex.id, objectVertex.version),
+        Reference(rootValueVertex.id, rootValueVertex.version),
+        propertyVertex.name,
+        propertyVertex.description,
+        propertyVertex.version
+    )
 }
 
 data class PropertyUpdateResult(private val propertyVertex: ObjectPropertyVertex, private val objectVertex: ObjectVertex) {
-    val id: String
-        get() = propertyVertex.id
 
-    val objectId: String
-        get() = objectVertex.id
-
-    val objectVersion: Int
-        get() = objectVertex.version
-
-    val name: String?
-        get() = propertyVertex.name
-
-    val description: String?
-        get() = propertyVertex.description
-
-    val version: Int
-        get() = propertyVertex.version
+    fun toResponse() = PropertyUpdateResponse(
+        propertyVertex.id,
+        Reference(objectVertex.id, objectVertex.version),
+        propertyVertex.name,
+        propertyVertex.description,
+        propertyVertex.version
+    )
 }
 
 data class PropertyDeleteResult(private val propertyVertex: ObjectPropertyVertex, private val objectVertex: ObjectVertex) {
-    val id: String
-        get() = propertyVertex.id
 
-    val objectId: String
-        get() = objectVertex.id
-
-    val objectVersion: Int
-        get() = objectVertex.version
-
-    val name: String?
-        get() = propertyVertex.name
-
-    val description: String?
-        get() = propertyVertex.description
-
-    val version: Int
-        get() = propertyVertex.version
+    fun toResponse() = PropertyDeleteResponse(
+        propertyVertex.id,
+        Reference(objectVertex.id, objectVertex.version),
+        propertyVertex.name,
+        propertyVertex.description,
+        propertyVertex.version
+    )
 }
 
 data class PropertyWriteInfo(

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectService.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/ObjectService.kt
@@ -148,8 +148,6 @@ class ObjectService(
         return objectUpdateResult.toResponse()
     }
 
-    private fun ObjectResult.toResponse() = ObjectChangeResponse(id, name, description, subjectId, subjectName, version)
-
     fun create(request: PropertyCreateRequest, username: String): PropertyCreateResponse {
         val userVertex = userService.findUserVertexByUsername(username)
         val context = HistoryContext(userVertex)
@@ -184,14 +182,7 @@ class ObjectService(
             )
         }
 
-        return PropertyCreateResponse(
-            propertyCreateResult.id,
-            Reference(propertyCreateResult.objectId, propertyCreateResult.objectVersion),
-            Reference(propertyCreateResult.rootValueId, propertyCreateResult.rootValueVersion),
-            propertyCreateResult.name,
-            propertyCreateResult.description,
-            propertyCreateResult.version
-        )
+        return propertyCreateResult.toResponse()
     }
 
     fun update(request: PropertyUpdateRequest, username: String): PropertyUpdateResponse {
@@ -211,13 +202,7 @@ class ObjectService(
             PropertyUpdateResult(propertyVertex, propertyVertex.objekt ?: throw IllegalStateException("Object property was created without object"))
         }
 
-        return PropertyUpdateResponse(
-            propertyUpdateResult.id,
-            Reference(propertyUpdateResult.objectId, propertyUpdateResult.objectVersion),
-            propertyUpdateResult.name,
-            propertyUpdateResult.description,
-            propertyUpdateResult.version
-        )
+        return propertyUpdateResult.toResponse()
     }
 
     fun create(request: ValueCreateRequest, username: String): ValueChangeResponse {
@@ -277,11 +262,6 @@ class ObjectService(
         }
     }
 
-    private fun ValueResult.toResponse() = ValueChangeResponse(
-        id, valueDto, description, measureName, Reference(objectPropertyId, objectPropertyVersion),
-        aspectPropertyId, parentValueId?.let { id -> parentValueVersion?.let { version -> Reference(id, version) } }, version
-    )
-
     private data class DeleteValueContext(
         val root: ObjectPropertyValueVertex,
         val values: Set<ObjectPropertyValueVertex>,
@@ -324,19 +304,7 @@ class ObjectService(
             )
         }
 
-        return ValueDeleteResponse(
-            valueDeleteResult.deletedValueIds,
-            valueDeleteResult.markedValueIds,
-            Reference(valueDeleteResult.propertyId, valueDeleteResult.propertyVersion),
-            valueDeleteResult.parentValueId?.let { parentId ->
-                valueDeleteResult.parentValueVersion?.let { parentVersion ->
-                    Reference(
-                        parentId,
-                        parentVersion
-                    )
-                }
-            }
-        )
+        return valueDeleteResult.toResponse()
     }
 
     fun softDeleteValue(id: String, username: String): ValueDeleteResponse {
@@ -366,19 +334,7 @@ class ObjectService(
             )
         }
 
-        return ValueDeleteResponse(
-            valueDeleteResult.deletedValueIds,
-            valueDeleteResult.markedValueIds,
-            Reference(valueDeleteResult.propertyId, valueDeleteResult.propertyVersion),
-            valueDeleteResult.parentValueId?.let { parentId ->
-                valueDeleteResult.parentValueVersion?.let { parentVersion ->
-                    Reference(
-                        parentId,
-                        parentVersion
-                    )
-                }
-            }
-        )
+        return valueDeleteResult.toResponse()
     }
 
     private data class DeletePropertyContext(
@@ -429,13 +385,7 @@ class ObjectService(
             PropertyDeleteResult(context.propVertex, ownerObject)
         }
 
-        return PropertyDeleteResponse(
-            propertyDeleteResult.id,
-            Reference(propertyDeleteResult.objectId, propertyDeleteResult.objectVersion),
-            propertyDeleteResult.name,
-            propertyDeleteResult.description,
-            propertyDeleteResult.version
-        )
+        return propertyDeleteResult.toResponse()
     }
 
     fun softDeleteProperty(id: String, username: String): PropertyDeleteResponse {
@@ -463,13 +413,7 @@ class ObjectService(
             PropertyDeleteResult(context.propVertex, ownerObject)
         }
 
-        return PropertyDeleteResponse(
-            propertyDeleteResult.id,
-            Reference(propertyDeleteResult.objectId, propertyDeleteResult.objectVersion),
-            propertyDeleteResult.name,
-            propertyDeleteResult.description,
-            propertyDeleteResult.version
-        )
+        return propertyDeleteResult.toResponse()
     }
 
     private data class DeleteObjectContext(

--- a/backend/src/main/kotlin/com/infowings/catalog/data/objekt/Objekt.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/data/objekt/Objekt.kt
@@ -1,6 +1,7 @@
 package com.infowings.catalog.data.objekt
 
 import com.infowings.catalog.common.ObjectGetResponse
+import com.infowings.catalog.common.objekt.ObjectChangeResponse
 import com.infowings.catalog.data.subject.SubjectVertex
 import com.infowings.catalog.storage.id
 import com.orientechnologies.orient.core.id.ORID
@@ -22,23 +23,15 @@ data class Objekt(
 )
 
 data class ObjectResult(private val objectVertex: ObjectVertex, private val subjectVertex: SubjectVertex) {
-    val id: String
-        get() = objectVertex.id
 
-    val name: String
-        get() = objectVertex.name
-
-    val description: String?
-        get() = objectVertex.description
-
-    val subjectId: String
-        get() = subjectVertex.id
-
-    val subjectName: String
-        get() = subjectVertex.name
-
-    val version: Int
-        get() = objectVertex.version
+    fun toResponse() = ObjectChangeResponse(
+        objectVertex.id,
+        objectVertex.name,
+        objectVertex.description,
+        subjectVertex.id,
+        subjectVertex.name,
+        objectVertex.version
+    )
 }
 
 data class ObjectTruncated(

--- a/backend/src/main/kotlin/com/infowings/catalog/external/AspectApi.kt
+++ b/backend/src/main/kotlin/com/infowings/catalog/external/AspectApi.kt
@@ -73,6 +73,13 @@ class AspectApi(val aspectService: AspectService) {
         aspectService.remove(aspect, username, true)
     }
 
+    @DeleteMapping("property/{id}")
+    fun removeAspectProperty(@PathVariable id: String, @RequestParam force: Boolean, principal: Principal): AspectPropertyDeleteResponse {
+        val username = principal.name
+        logger.debug("Remove aspect property request: $id by $username")
+        return aspectService.removeProperty(id, username, force)
+    }
+
     @ExceptionHandler(AspectException::class)
     fun handleAspectException(exception: AspectException): ResponseEntity<String> {
         logger.error(exception.toString(), exception)
@@ -155,6 +162,15 @@ class AspectApi(val aspectService: AspectService) {
                         BadRequest(
                             BadRequestCode.NEED_CONFIRMATION,
                             "Attempt to remove aspect that has linked entities pointed to it"
+                        )
+                    )
+                )
+            is AspectPropertyIsLinkedByValue -> ResponseEntity.badRequest()
+                .body(
+                    JSON.stringify(
+                        BadRequest(
+                            BadRequestCode.NEED_CONFIRMATION,
+                            "Attempt to remove aspect property that is linked by other entities"
                         )
                     )
                 )

--- a/backend/src/test/kotlin/com/infowings/catalog/AbstractMvcTest.kt
+++ b/backend/src/test/kotlin/com/infowings/catalog/AbstractMvcTest.kt
@@ -23,6 +23,7 @@ import org.springframework.web.context.WebApplicationContext
 
 @ExtendWith(SpringExtension::class)
 @SpringBootTest
+@Suppress("UnsafeCallOnNullableType")
 abstract class AbstractMvcTest {
 
     @Autowired

--- a/backend/src/test/kotlin/com/infowings/catalog/AbstractMvcTest.kt
+++ b/backend/src/test/kotlin/com/infowings/catalog/AbstractMvcTest.kt
@@ -4,6 +4,9 @@ import com.infowings.catalog.common.AspectData
 import com.infowings.catalog.data.Subject
 import com.infowings.catalog.data.aspect.AspectService
 import com.infowings.catalog.data.toSubjectData
+import com.infowings.catalog.storage.OrientClass
+import com.infowings.catalog.storage.OrientDatabase
+import com.infowings.catalog.storage.transaction
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -23,20 +26,43 @@ import org.springframework.web.context.WebApplicationContext
 abstract class AbstractMvcTest {
 
     @Autowired
+    private lateinit var orientDatabase: OrientDatabase
+
+    @Autowired
     private lateinit var wac: WebApplicationContext
 
     protected lateinit var mockMvc: MockMvc
 
-    protected val authorities = user("admin").authorities(SimpleGrantedAuthority("ADMIN"))
+    protected val authorities = user("admin").authorities(SimpleGrantedAuthority("ADMIN"))!!
 
     @BeforeEach
-    fun setup() {
+    fun setupMvcAndDatabase() {
+        setupMockMvc()
+        cleanupDatabase()
+    }
+
+    private fun setupMockMvc() {
         mockMvc = MockMvcBuilders.webAppContextSetup(wac)
             .apply<DefaultMockMvcBuilder>(SecurityMockMvcConfigurers.springSecurity())
             .alwaysDo<DefaultMockMvcBuilder>(MockMvcResultHandlers.print())
             .build()
     }
 
+    private fun cleanupDatabase() {
+        transaction(orientDatabase) {
+            orientDatabase.command("DELETE VERTEX ${OrientClass.ASPECT.extName}") {}
+            orientDatabase.command("DELETE VERTEX ${OrientClass.ASPECT_PROPERTY.extName}") {}
+            orientDatabase.command("DELETE VERTEX ${OrientClass.SUBJECT.extName}") {}
+            orientDatabase.command("DELETE VERTEX ${OrientClass.OBJECT.extName}") {}
+            orientDatabase.command("DELETE VERTEX ${OrientClass.OBJECT_PROPERTY.extName}") {}
+            orientDatabase.command("DELETE VERTEX ${OrientClass.OBJECT_VALUE.extName}") {}
+            orientDatabase.command("DELETE VERTEX ${OrientClass.REFBOOK_ITEM.extName}") {}
+            orientDatabase.command("DELETE VERTEX ${OrientClass.HISTORY_ADD_LINK.extName}") {}
+            orientDatabase.command("DELETE VERTEX ${OrientClass.HISTORY_ELEMENT.extName}") {}
+            orientDatabase.command("DELETE VERTEX ${OrientClass.HISTORY_EVENT.extName}") {}
+            orientDatabase.command("DELETE VERTEX ${OrientClass.HISTORY_REMOVE_LINK.extName}") {}
+        }
+    }
 }
 
 fun createTestAspect(

--- a/backend/src/test/kotlin/com/infowings/catalog/data/aspect/AspectPropertyDeletingTest.kt
+++ b/backend/src/test/kotlin/com/infowings/catalog/data/aspect/AspectPropertyDeletingTest.kt
@@ -1,72 +1,26 @@
 package com.infowings.catalog.data.aspect
 
+import com.infowings.catalog.AbstractMvcTest
 import com.infowings.catalog.common.*
 import com.infowings.catalog.common.objekt.ObjectChangeResponse
 import com.infowings.catalog.common.objekt.ObjectCreateRequest
 import com.infowings.catalog.common.objekt.PropertyCreateRequest
 import com.infowings.catalog.common.objekt.ValueCreateRequest
-import com.infowings.catalog.storage.OrientClass
-import com.infowings.catalog.storage.OrientDatabase
-import com.infowings.catalog.storage.transaction
 import io.kotlintest.shouldBe
 import kotlinx.serialization.json.JSON
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
-import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
-import org.springframework.security.core.authority.SimpleGrantedAuthority
-import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
-import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
-import org.springframework.test.web.servlet.setup.MockMvcBuilders
-import org.springframework.web.context.WebApplicationContext
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
-@ExtendWith(SpringExtension::class)
-@SpringBootTest
-@Suppress("UnsafeCallOnNullableType")
-class AspectPropertyDeletingTest {
+@Suppress("UnsafeCallOnNullableType", "StringLiteralDuplication", "MagicNumber")
+class AspectPropertyDeletingTest : AbstractMvcTest() {
 
-    @Autowired
-    lateinit var db: OrientDatabase
-
-    @Autowired
-    lateinit var webApplicationContext: WebApplicationContext
-
-    private lateinit var mockMvc: MockMvc
-
-    private val authorities = SecurityMockMvcRequestPostProcessors.user("admin").authorities(SimpleGrantedAuthority("ADMIN"))
-
-    private fun tearDownAllVertices() {
-        transaction(db) {
-            db.command("DELETE VERTEX ${OrientClass.ASPECT.extName}") {}
-            db.command("DELETE VERTEX ${OrientClass.ASPECT_PROPERTY.extName}") {}
-            db.command("DELETE VERTEX ${OrientClass.SUBJECT.extName}") {}
-            db.command("DELETE VERTEX ${OrientClass.OBJECT.extName}") {}
-            db.command("DELETE VERTEX ${OrientClass.OBJECT_PROPERTY.extName}") {}
-            db.command("DELETE VERTEX ${OrientClass.OBJECT_VALUE.extName}") {}
-            db.command("DELETE VERTEX ${OrientClass.REFBOOK_ITEM.extName}") {}
-            db.command("DELETE VERTEX ${OrientClass.HISTORY_ADD_LINK.extName}") {}
-            db.command("DELETE VERTEX ${OrientClass.HISTORY_ELEMENT.extName}") {}
-            db.command("DELETE VERTEX ${OrientClass.HISTORY_EVENT.extName}") {}
-            db.command("DELETE VERTEX ${OrientClass.HISTORY_REMOVE_LINK.extName}") {}
-        }
-    }
-
-    private fun setUpMockMvc() {
-        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
-            .apply<DefaultMockMvcBuilder>(SecurityMockMvcConfigurers.springSecurity())
-            .build()
-    }
-
-    private fun setUpCommonData() {
+    @BeforeEach
+    fun setUpCommonData() {
         val knetSubject: SubjectData
         val subjectDataRequestResult = mockMvc.perform(
             MockMvcRequestBuilders.post("/api/subject/create")
@@ -138,13 +92,6 @@ class AspectPropertyDeletingTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(JSON.stringify(PropertyCreateRequest(objectBoxCreateResponse.id, null, null, aspectDimensions.id!!)))
         ).andReturn()
-    }
-
-    @BeforeEach
-    fun cleanDatabaseBeforeTest() {
-        tearDownAllVertices()
-        setUpMockMvc()
-        setUpCommonData()
     }
 
     @Test

--- a/backend/src/test/kotlin/com/infowings/catalog/data/aspect/AspectPropertyDeletingTest.kt
+++ b/backend/src/test/kotlin/com/infowings/catalog/data/aspect/AspectPropertyDeletingTest.kt
@@ -1,0 +1,290 @@
+package com.infowings.catalog.data.aspect
+
+import com.infowings.catalog.common.*
+import com.infowings.catalog.common.objekt.ObjectChangeResponse
+import com.infowings.catalog.common.objekt.ObjectCreateRequest
+import com.infowings.catalog.common.objekt.PropertyCreateRequest
+import com.infowings.catalog.common.objekt.ValueCreateRequest
+import com.infowings.catalog.storage.OrientClass
+import com.infowings.catalog.storage.OrientDatabase
+import com.infowings.catalog.storage.transaction
+import io.kotlintest.shouldBe
+import kotlinx.serialization.json.JSON
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@ExtendWith(SpringExtension::class)
+@SpringBootTest
+@Suppress("UnsafeCallOnNullableType")
+class AspectPropertyDeletingTest {
+
+    @Autowired
+    lateinit var db: OrientDatabase
+
+    @Autowired
+    lateinit var webApplicationContext: WebApplicationContext
+
+    private lateinit var mockMvc: MockMvc
+
+    private val authorities = SecurityMockMvcRequestPostProcessors.user("admin").authorities(SimpleGrantedAuthority("ADMIN"))
+
+    private fun tearDownAllVertices() {
+        transaction(db) {
+            db.command("DELETE VERTEX ${OrientClass.ASPECT.extName}") {}
+            db.command("DELETE VERTEX ${OrientClass.ASPECT_PROPERTY.extName}") {}
+            db.command("DELETE VERTEX ${OrientClass.SUBJECT.extName}") {}
+            db.command("DELETE VERTEX ${OrientClass.OBJECT.extName}") {}
+            db.command("DELETE VERTEX ${OrientClass.OBJECT_PROPERTY.extName}") {}
+            db.command("DELETE VERTEX ${OrientClass.OBJECT_VALUE.extName}") {}
+            db.command("DELETE VERTEX ${OrientClass.REFBOOK_ITEM.extName}") {}
+            db.command("DELETE VERTEX ${OrientClass.HISTORY_ADD_LINK.extName}") {}
+            db.command("DELETE VERTEX ${OrientClass.HISTORY_ELEMENT.extName}") {}
+            db.command("DELETE VERTEX ${OrientClass.HISTORY_EVENT.extName}") {}
+            db.command("DELETE VERTEX ${OrientClass.HISTORY_REMOVE_LINK.extName}") {}
+        }
+    }
+
+    private fun setUpMockMvc() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .apply<DefaultMockMvcBuilder>(SecurityMockMvcConfigurers.springSecurity())
+            .build()
+    }
+
+    private fun setUpCommonData() {
+        val knetSubject: SubjectData
+        val subjectDataRequestResult = mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/subject/create")
+                .with(authorities)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(JSON.stringify(SubjectData(null, "Knowledge Net Demo", 0, null, false)))
+        ).andReturn()
+        knetSubject = JSON.parse(subjectDataRequestResult.response.contentAsString)
+
+        val aspectHeight: AspectData
+        val aspectHeightRequestResult = mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/aspect/create")
+                .with(authorities)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(JSON.stringify(AspectData(name = "Height", measure = Millimetre.name, baseType = BaseType.Decimal.name)))
+        ).andReturn()
+        aspectHeight = JSON.parse(aspectHeightRequestResult.response.contentAsString)
+
+        val aspectWidth: AspectData
+        val aspectWidthRequestResult = mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/aspect/create")
+                .with(authorities)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(JSON.stringify(AspectData(name = "Width", measure = Millimetre.name, baseType = BaseType.Decimal.name)))
+        ).andReturn()
+        aspectWidth = JSON.parse(aspectWidthRequestResult.response.contentAsString)
+
+        val aspectDepth: AspectData
+        val aspectDepthRequestResult = mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/aspect/create")
+                .with(authorities)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(JSON.stringify(AspectData(name = "Depth", measure = Millimetre.name, baseType = BaseType.Decimal.name)))
+        ).andReturn()
+        aspectDepth = JSON.parse(aspectDepthRequestResult.response.contentAsString)
+
+        val aspectDimensions: AspectData
+        val aspectDimensionsRequestResult = mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/aspect/create")
+                .with(authorities)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(JSON.stringify(
+                    AspectData(
+                        name = "Dimensions",
+                        measure = Millimetre.name,
+                        baseType = BaseType.Decimal.name,
+                        properties = listOf(
+                            AspectPropertyData("", null, aspectHeight.id!!, PropertyCardinality.ONE.name, null),
+                            AspectPropertyData("", null, aspectWidth.id!!, PropertyCardinality.ONE.name, null),
+                            AspectPropertyData("", null, aspectDepth.id!!, PropertyCardinality.ONE.name, null)
+                        )
+                    )
+                ))
+        ).andReturn()
+        aspectDimensions = JSON.parse(aspectDimensionsRequestResult.response.contentAsString)
+
+        val objectBoxCreateResponse: ObjectChangeResponse
+        val objectBoxRequestResult = mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/objects/create")
+                .with(authorities)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(JSON.stringify(ObjectCreateRequest("Box", null, knetSubject.id!!)))
+        ).andReturn()
+        objectBoxCreateResponse = JSON.parse(objectBoxRequestResult.response.contentAsString)
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/objects/createProperty")
+                .with(authorities)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(JSON.stringify(PropertyCreateRequest(objectBoxCreateResponse.id, null, null, aspectDimensions.id!!)))
+        ).andReturn()
+    }
+
+    @BeforeEach
+    fun cleanDatabaseBeforeTest() {
+        tearDownAllVertices()
+        setUpMockMvc()
+        setUpCommonData()
+    }
+
+    @Test
+    fun `Deleting aspect property that is not linked should result in correct response`() {
+        val aspectList = fetchAspectList()
+        val aspectDimensions = aspectList.find { it.name == "Dimensions" }!!
+        val aspectHeight = aspectList.find { it.name == "Height" }!!
+        val aspectPropertyHeight = aspectDimensions.properties.find { it.aspectId == aspectHeight.id }!!
+
+        val propertyHeightDeleteResponse: AspectPropertyDeleteResponse
+        val deleteAspectPropertyResult = mockMvc.perform(
+            MockMvcRequestBuilders.delete("/api/aspect/property/{id}?force={force}", aspectPropertyHeight.id, false)
+                .with(authorities)
+        ).andReturn()
+        propertyHeightDeleteResponse = JSON.parse(deleteAspectPropertyResult.response.contentAsString)
+
+        assertAll(
+            "Delete response contains correct structure",
+            { propertyHeightDeleteResponse.id               shouldBe aspectPropertyHeight.id },
+            { propertyHeightDeleteResponse.cardinality.name shouldBe aspectPropertyHeight.cardinality },
+            { propertyHeightDeleteResponse.name             shouldBe aspectPropertyHeight.name },
+            { propertyHeightDeleteResponse.parentAspect.id  shouldBe aspectDimensions.id },
+            { propertyHeightDeleteResponse.childAspect.id   shouldBe aspectHeight.id }
+        )
+    }
+
+    @Test
+    fun `Deleting aspect property that is not linked should result in absence of the property in next response`() {
+        val setupAspectList = fetchAspectList()
+        val setupAspectDimensions = setupAspectList.find { it.name == "Dimensions" }!!
+        val setupAspectHeight = setupAspectList.find { it.name == "Height" }!!
+        val setupAspectPropertyHeight = setupAspectDimensions.properties.find { it.aspectId == setupAspectHeight.id }!!
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.delete("/api/aspect/property/{id}?force={force}", setupAspectPropertyHeight.id, false)
+                .with(authorities)
+        ).andReturn()
+
+        val newAspectList = fetchAspectList()
+        val newAspectDimensions = newAspectList.find { it.name == "Dimensions" }!!
+        val newAspectHeight = newAspectList.find { it.name == "Height" }!!
+        val newAspectWidth = newAspectList.find { it.name == "Width" }!!
+        val newAspectDepth = newAspectList.find { it.name == "Depth" }!!
+
+        assertAll (
+            "Dimensions aspect after property deletion should not contain deleted property",
+            { newAspectDimensions.properties.size shouldBe 2 },
+            { assertNotNull(newAspectDimensions.properties.find { it.aspectId == newAspectWidth.id }) },
+            { assertNotNull(newAspectDimensions.properties.find { it.aspectId == newAspectDepth.id }) },
+            { assertNull(newAspectDimensions.properties.find { it.aspectId == newAspectHeight.id }) }
+        )
+    }
+
+    @Test
+    fun `Non-force deletion of linked aspect property should result in exception`() {
+        val objectBoxEditDetails = fetchObjectBoxEditDetails()
+        val boxDimensionsPropertyId = objectBoxEditDetails.properties.single().id
+        val boxDimensionsValueId = objectBoxEditDetails.properties.single().rootValues.single().id
+        val aspectPropertyHeightId = objectBoxEditDetails.properties.single().aspectDescriptor.properties.find { it.aspect.name == "Height" }!!.id
+
+        linkAspectHeightWithValue(boxDimensionsPropertyId, aspectPropertyHeightId, boxDimensionsValueId)
+
+        val deleteHeightPropertyRequestResult = mockMvc.perform(
+            MockMvcRequestBuilders.delete("/api/aspect/property/{id}?force={force}", aspectPropertyHeightId, false)
+                .with(authorities)
+        ).andReturn()
+
+        assertAll(
+            "Delete linked aspect response should be of status 400 and contain BadRequest information in body",
+            { deleteHeightPropertyRequestResult.response.status shouldBe 400 },
+            { JSON.parse<BadRequest>(deleteHeightPropertyRequestResult.response.contentAsString).code shouldBe BadRequestCode.NEED_CONFIRMATION }
+        )
+    }
+
+    @Test
+    fun `Force deletion of linked aspect property should result successful response`() {
+        val objectBoxEditDetails = fetchObjectBoxEditDetails()
+        val boxDimensionsPropertyId = objectBoxEditDetails.properties.single().id
+        val boxDimensionsValueId = objectBoxEditDetails.properties.single().rootValues.single().id
+        val boxDimensionsValueAspectId = objectBoxEditDetails.properties.single().aspectDescriptor.id
+        val aspectPropertyHeight = objectBoxEditDetails.properties.single().aspectDescriptor.properties.find { it.aspect.name == "Height" }!!
+
+        linkAspectHeightWithValue(boxDimensionsPropertyId, aspectPropertyHeight.id, boxDimensionsValueId)
+
+        val deleteHeightPropertyResponse: AspectPropertyDeleteResponse
+        val deleteHeightPropertyRequestResult = mockMvc.perform(
+            MockMvcRequestBuilders.delete("/api/aspect/property/{id}?force={force}", aspectPropertyHeight.id, true)
+                .with(authorities)
+        ).andReturn()
+        deleteHeightPropertyResponse = JSON.parse(deleteHeightPropertyRequestResult.response.contentAsString)
+
+        assertAll(
+            "Delete response contains correct structure",
+            { deleteHeightPropertyResponse.id              shouldBe aspectPropertyHeight.id },
+            { deleteHeightPropertyResponse.cardinality     shouldBe aspectPropertyHeight.cardinality },
+            { deleteHeightPropertyResponse.name            shouldBe aspectPropertyHeight.name },
+            { deleteHeightPropertyResponse.parentAspect.id shouldBe boxDimensionsValueAspectId },
+            { deleteHeightPropertyResponse.childAspect.id  shouldBe aspectPropertyHeight.aspect.id }
+        )
+    }
+
+    private fun fetchAspectList(): List<AspectData> {
+        val getAspectListResult = mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/aspect/all?orderFields=&direct=&q=")
+                .with(authorities)
+        ).andReturn()
+        return JSON.parse<AspectsList>(getAspectListResult.response.contentAsString).aspects
+    }
+
+    private fun fetchObjectBoxEditDetails(): ObjectEditDetailsResponse {
+        val objectsTruncatedList: List<ObjectGetResponse>
+        val objectsTruncatedListRequestResult = mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/objects")
+                .with(authorities)
+        ).andReturn()
+        objectsTruncatedList = JSON.parse<ObjectsResponse>(objectsTruncatedListRequestResult.response.contentAsString).objects
+        val boxObjectTruncated = objectsTruncatedList.find { it.name == "Box" }!!
+
+        val objectBoxEditDetailsRequestResult = mockMvc.perform(
+            MockMvcRequestBuilders.get("/api/objects/{id}/editdetails", boxObjectTruncated.id)
+                .with(authorities)
+        ).andReturn()
+        return JSON.parse(objectBoxEditDetailsRequestResult.response.contentAsString)
+    }
+
+    private fun linkAspectHeightWithValue(objectPropertyId: String, aspectPropertyId: String, parentValueId: String) {
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/objects/createValue")
+                .with(authorities)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(JSON.stringify(
+                    ValueCreateRequest(
+                        ObjectValueData.DecimalValue("42.5"),
+                        null,
+                        objectPropertyId,
+                        Millimetre.name,
+                        aspectPropertyId,
+                        parentValueId
+                    ).toDTO()
+                ))
+        )
+    }
+}

--- a/backend/src/test/kotlin/com/infowings/catalog/data/measure/ValueEditingMeasureValidationTest.kt
+++ b/backend/src/test/kotlin/com/infowings/catalog/data/measure/ValueEditingMeasureValidationTest.kt
@@ -1,73 +1,27 @@
 package com.infowings.catalog.data.measure
 
+import com.infowings.catalog.AbstractMvcTest
 import com.infowings.catalog.common.*
 import com.infowings.catalog.common.objekt.*
-import com.infowings.catalog.storage.OrientClass
-import com.infowings.catalog.storage.OrientDatabase
-import com.infowings.catalog.storage.transaction
 import io.kotlintest.matchers.types.shouldBeTypeOf
 import io.kotlintest.shouldThrow
 import kotlinx.serialization.json.JSON
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
-import org.springframework.security.core.authority.SimpleGrantedAuthority
-import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
-import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
-import org.springframework.test.web.servlet.setup.MockMvcBuilders
-import org.springframework.web.context.WebApplicationContext
 import org.springframework.web.util.NestedServletException
 
-@ExtendWith(SpringExtension::class)
-@SpringBootTest
 @Suppress("UnsafeCallOnNullableType")
-class ValueEditingMeasureValidationTest {
-
-    @Autowired
-    lateinit var db: OrientDatabase
-
-    @Autowired
-    lateinit var webApplicationContext: WebApplicationContext
-
-    private lateinit var mockMvc: MockMvc
-
-    private val authorities = SecurityMockMvcRequestPostProcessors.user("admin").authorities(SimpleGrantedAuthority("ADMIN"))
+class ValueEditingMeasureValidationTest : AbstractMvcTest() {
 
     private lateinit var knetSubject: SubjectData
     private lateinit var aspectHeight: AspectData
     private lateinit var tubeObject: ObjectChangeResponse
     private lateinit var tubeObjectHeightProperty: PropertyCreateResponse
 
-    private fun initializeMockMvc() {
-        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
-            .apply<DefaultMockMvcBuilder>(SecurityMockMvcConfigurers.springSecurity())
-            .build()
-    }
-
-    private fun tearDownAllVertices() {
-        transaction(db) {
-            db.command("DELETE VERTEX ${OrientClass.ASPECT.extName}") {}
-            db.command("DELETE VERTEX ${OrientClass.ASPECT_PROPERTY.extName}") {}
-            db.command("DELETE VERTEX ${OrientClass.SUBJECT.extName}") {}
-            db.command("DELETE VERTEX ${OrientClass.OBJECT.extName}") {}
-            db.command("DELETE VERTEX ${OrientClass.OBJECT_PROPERTY.extName}") {}
-            db.command("DELETE VERTEX ${OrientClass.OBJECT_VALUE.extName}") {}
-            db.command("DELETE VERTEX ${OrientClass.REFBOOK_ITEM.extName}") {}
-            db.command("DELETE VERTEX ${OrientClass.HISTORY_ADD_LINK.extName}") {}
-            db.command("DELETE VERTEX ${OrientClass.HISTORY_ELEMENT.extName}") {}
-            db.command("DELETE VERTEX ${OrientClass.HISTORY_EVENT.extName}") {}
-            db.command("DELETE VERTEX ${OrientClass.HISTORY_REMOVE_LINK.extName}") {}
-        }
-    }
-
-    private fun initializeData() {
+    @BeforeEach
+    fun initializeData() {
         val subjectDataRequestResult = mockMvc.perform(
             MockMvcRequestBuilders.post("/api/subject/create")
                 .with(authorities)
@@ -100,13 +54,6 @@ class ValueEditingMeasureValidationTest {
         ).andReturn()
         tubeObjectHeightProperty = JSON.parse(tubeObjectPropertyRequestResult.response.contentAsString)
         tubeObject = tubeObject.copy(version = tubeObjectHeightProperty.obj.version)
-    }
-
-    @BeforeEach
-    fun refreshDatabase() {
-        initializeMockMvc()
-        tearDownAllVertices()
-        initializeData()
     }
 
     @Test

--- a/common/src/main/kotlin/com/infowings/catalog/common/AspectData.kt
+++ b/common/src/main/kotlin/com/infowings/catalog/common/AspectData.kt
@@ -1,5 +1,6 @@
 package com.infowings.catalog.common
 
+import com.infowings.catalog.common.objekt.Reference
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -92,6 +93,15 @@ data class AspectPropertyTree(
     val name: String?,
     val aspect: AspectTree,
     val deleted: Boolean
+)
+
+@Serializable
+data class AspectPropertyDeleteResponse(
+    val id: String,
+    val cardinality: PropertyCardinality,
+    val name: String?,
+    val parentAspect: Reference,
+    val childAspect: Reference
 )
 
 /** Helpful extensions */

--- a/frontend/src/main/kotlin/com/infowings/catalog/aspects/AspectApi.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/aspects/AspectApi.kt
@@ -1,6 +1,7 @@
 package com.infowings.catalog.aspects
 
 import com.infowings.catalog.common.*
+import com.infowings.catalog.utils.delete
 import com.infowings.catalog.utils.encodeURIComponent
 import com.infowings.catalog.utils.get
 import com.infowings.catalog.utils.post
@@ -25,6 +26,9 @@ suspend fun createAspect(body: AspectData): AspectData = JSON.parse(post("/api/a
 suspend fun updateAspect(body: AspectData): AspectData = JSON.parse(post("/api/aspect/update", JSON.stringify(body)))
 
 suspend fun removeAspect(body: AspectData) = post("/api/aspect/remove", JSON.stringify(body))
+
+suspend fun removeAspectProperty(id: String, force: Boolean = false): AspectPropertyDeleteResponse =
+    JSON.parse(delete("/api/aspect/property/${encodeURIComponent(id)}?force=$force"))
 
 suspend fun forceRemoveAspect(body: AspectData) = post("/api/aspect/forceRemove", JSON.stringify(body))
 

--- a/frontend/src/main/kotlin/com/infowings/catalog/aspects/editconsole/AspectConsole.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/aspects/editconsole/AspectConsole.kt
@@ -5,7 +5,6 @@ import com.infowings.catalog.common.AspectData
 import com.infowings.catalog.common.AspectPropertyData
 import com.infowings.catalog.common.emptyAspectPropertyData
 import kotlinext.js.require
-import kotlinx.coroutines.experimental.launch
 import react.*
 
 interface AspectEditConsoleModel {
@@ -62,7 +61,7 @@ interface AspectPropertyEditConsoleModel {
      * Save currently edited [AspectPropertyData] as deleted and switch to editing next available [AspectPropertyData]
      * if such exist or to parent [AspectData] otherwise
      */
-    fun deleteProperty()
+    suspend fun deleteProperty(force: Boolean)
 }
 
 /**
@@ -128,10 +127,8 @@ class AspectConsole : RComponent<AspectConsole.Props, RState>(), AspectEditConso
         props.aspectsModel.deleteAspect(force)
     }
 
-    override fun deleteProperty() {
-        launch {
-            props.aspectsModel.deleteAspectProperty()
-        }
+    override suspend fun deleteProperty(force: Boolean) {
+        props.aspectsModel.deleteAspectProperty(force)
     }
 
     override fun discardChanges() {

--- a/frontend/src/main/kotlin/com/infowings/catalog/aspects/editconsole/AspectPropertyEditConsole.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/aspects/editconsole/AspectPropertyEditConsole.kt
@@ -60,9 +60,6 @@ class AspectPropertyEditConsole(props: Props) :
         launch {
             try {
                 props.propertyEditConsoleModel.deleteProperty(force)
-                setState {
-                    confirmation = false
-                }
             } catch (ex: AspectBadRequestException) {
                 if (ex.exceptionInfo.code == BadRequestCode.NEED_CONFIRMATION) setState {
                     confirmation = true

--- a/frontend/src/main/kotlin/com/infowings/catalog/aspects/editconsole/AspectPropertyEditConsole.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/aspects/editconsole/AspectPropertyEditConsole.kt
@@ -1,19 +1,22 @@
 package com.infowings.catalog.aspects.editconsole
 
+import com.infowings.catalog.aspects.AspectBadRequestException
 import com.infowings.catalog.aspects.editconsole.aspectproperty.aspectPropertyAspect
 import com.infowings.catalog.aspects.editconsole.aspectproperty.aspectPropertyCardinality
 import com.infowings.catalog.aspects.editconsole.aspectproperty.aspectPropertyNameInput
 import com.infowings.catalog.aspects.editconsole.view.aspectConsoleBlock
 import com.infowings.catalog.aspects.editconsole.view.consoleButtonsGroup
 import com.infowings.catalog.common.AspectData
+import com.infowings.catalog.common.BadRequestCode
 import com.infowings.catalog.components.description.descriptionComponent
+import com.infowings.catalog.components.popup.forceRemoveConfirmWindow
 import kotlinx.coroutines.experimental.launch
 import org.w3c.dom.HTMLInputElement
 import react.*
 import react.dom.div
 
 class AspectPropertyEditConsole(props: Props) :
-    RComponent<AspectPropertyEditConsole.Props, RState>(props) {
+    RComponent<AspectPropertyEditConsole.Props, AspectPropertyEditConsole.State>(props) {
 
     private var inputRef: HTMLInputElement? = null
 
@@ -53,6 +56,20 @@ class AspectPropertyEditConsole(props: Props) :
         }
     }
 
+    private fun tryDelete(force: Boolean) {
+        launch {
+            try {
+                props.propertyEditConsoleModel.deleteProperty(force)
+                setState {
+                    confirmation = false
+                }
+            } catch (ex: AspectBadRequestException) {
+                if (ex.exceptionInfo.code == BadRequestCode.NEED_CONFIRMATION) setState {
+                    confirmation = true
+                }
+            }
+        }
+    }
 
     private fun handlePropertyNameChanged(name: String) {
         props.propertyEditConsoleModel.updateAspectProperty(
@@ -128,10 +145,23 @@ class AspectPropertyEditConsole(props: Props) :
                     onSubmitClick = ::trySubmitParentAspect,
                     onCancelClick = props.propertyEditConsoleModel::discardChanges,
                     onAddToListClick = ::switchToNextProperty,
-                    onDeleteClick = props.propertyEditConsoleModel::deleteProperty
+                    onDeleteClick = { tryDelete(false) }
                 )
             }
         }
+
+        forceRemoveConfirmWindow {
+            attrs {
+                onConfirm = { tryDelete(true) }
+                onCancel = { setState { confirmation = false } }
+                isOpen = state.confirmation
+                message = "Aspect property has linked entities."
+            }
+        }
+    }
+
+    interface State : RState {
+        var confirmation: Boolean
     }
 
     interface Props : RProps {

--- a/frontend/src/main/kotlin/com/infowings/catalog/aspects/model/AspectModel.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/aspects/model/AspectModel.kt
@@ -63,5 +63,5 @@ interface AspectsModel {
      */
     suspend fun deleteAspect(force: Boolean)
 
-    suspend fun deleteAspectProperty()
+    suspend fun deleteAspectProperty(force: Boolean)
 }

--- a/frontend/src/main/kotlin/com/infowings/catalog/aspects/model/DefaultAspectsModelComponent.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/aspects/model/DefaultAspectsModelComponent.kt
@@ -210,8 +210,6 @@ class DefaultAspectsModelComponent : RComponent<AspectApiReceiverProps, DefaultA
     }
 
     private fun State.isSelectedAspectHasChanges(): Boolean {
-        console.log(this.selectedAspect)
-        console.log(props.aspectContext[selectedAspect.id])
         return selectedAspect != props.aspectContext[selectedAspect.id] && selectedAspect != emptyAspectData
     }
 

--- a/frontend/src/main/kotlin/com/infowings/catalog/aspects/model/DefaultAspectsModelComponent.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/aspects/model/DefaultAspectsModelComponent.kt
@@ -209,9 +209,8 @@ class DefaultAspectsModelComponent : RComponent<AspectApiReceiverProps, DefaultA
         else -> false
     }
 
-    private fun State.isSelectedAspectHasChanges(): Boolean {
-        return selectedAspect != props.aspectContext[selectedAspect.id] && selectedAspect != emptyAspectData
-    }
+    private fun State.isSelectedAspectHasChanges() =
+        selectedAspect != props.aspectContext[selectedAspect.id] && selectedAspect != emptyAspectData
 
     private fun State.isEmptyPropertySelected() =
         selectedAspectPropertyIndex != null && selectedAspect.properties[selectedAspectPropertyIndex!!] == emptyAspectPropertyData

--- a/frontend/src/main/kotlin/com/infowings/catalog/aspects/model/EmptyAspectModel.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/aspects/model/EmptyAspectModel.kt
@@ -29,7 +29,7 @@ class EmptyAspectModelComponent : RComponent<EmptyAspectModelComponent.Props, Em
 
     override suspend fun deleteAspect(force: Boolean) {}
 
-    override suspend fun deleteAspectProperty() {}
+    override suspend fun deleteAspectProperty(force: Boolean) {}
 
     override fun EmptyAspectModelComponent.State.init() {
         data = emptyList()

--- a/frontend/src/main/kotlin/com/infowings/catalog/aspects/treeview/AspectProperties.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/aspects/treeview/AspectProperties.kt
@@ -112,7 +112,7 @@ class AspectPropertyNodeExpandedWrapper(props: Props) :
                 }!!
             }
 
-            if (childAspect != null && childAspect.properties.isNotEmpty()) {
+            if (childAspect != null && childAspect.properties.filterNot { it.deleted }.isNotEmpty()) {
                 aspectProperties {
                     attrs {
                         aspect = childAspect

--- a/frontend/src/main/kotlin/com/infowings/catalog/aspects/treeview/AspectTreeView.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/aspects/treeview/AspectTreeView.kt
@@ -132,7 +132,9 @@ class AspectNodeExpandedStateWrapper :
                 }!!
             }
 
-            if (props.aspect.properties.isNotEmpty() || (props.aspect.id == props.selectedAspectId && props.selectedPropertyIndex != null)) {
+            if (props.aspect.properties.filterNot { it.deleted }.isNotEmpty()
+                || (props.aspect.id == props.selectedAspectId && props.selectedPropertyIndex != null)
+            ) {
                 aspectProperties {
                     attrs {
                         this.aspect = props.aspect

--- a/frontend/src/main/kotlin/com/infowings/catalog/aspects/treeview/AspectTreeView.kt
+++ b/frontend/src/main/kotlin/com/infowings/catalog/aspects/treeview/AspectTreeView.kt
@@ -132,9 +132,7 @@ class AspectNodeExpandedStateWrapper :
                 }!!
             }
 
-            if (props.aspect.properties.filterNot { it.deleted }.isNotEmpty()
-                || (props.aspect.id == props.selectedAspectId && props.selectedPropertyIndex != null)
-            ) {
+            if (props.aspect.properties.filterNot { it.deleted }.isNotEmpty() || childPropertyIsSelected()) {
                 aspectProperties {
                     attrs {
                         this.aspect = props.aspect
@@ -149,6 +147,8 @@ class AspectNodeExpandedStateWrapper :
             }
         }
     }
+
+    private fun childPropertyIsSelected() = props.aspect.id == props.selectedAspectId && props.selectedPropertyIndex != null
 
     interface State : RState {
         var expandedSubtree: Boolean


### PR DESCRIPTION
* API endpoint for deleting aspect property
* Frontend is altered accordingly to use new endpoints for deleting aspect property
* Confirmation window for aspect property removal when aspect property is linked
* Fixed aspect business key verification (get aspect with the same name and no subject) (#287)
* Fixed aspect property rendering issues (when all aspect properties are removed, aspect or aspect property node in aspect tree on aspect page should not be expandable) (#288)